### PR TITLE
Improved optional handling

### DIFF
--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -2973,9 +2973,6 @@ void PrintSeqDefCodeBerDecodeContent(FILE* src, FILE* hdr, Module* m, CxxRules* 
 		else if (iNotContextSpecificOptionals == 0 && iFirstContextOptionalStartsWith == 0)
 			parser = OPTIONALSTATE_BEFOREFIRST;
 
-		if (parser == OPTIONALSTATE_BEFOREFIRST)
-			printf("Alternative matching for %s\n", td->cxxTypeDefInfo->className);
-
 		FOR_EACH_LIST_ELMT(e, seq->basicType->a.sequence)
 		{
 			if (IsDeprecatedNoOutputMember(m, td, e->type->cxxTypeRefInfo->fieldName))

--- a/compiler/back-ends/c-gen/gen-code.c
+++ b/compiler/back-ends/c-gen/gen-code.c
@@ -111,7 +111,8 @@
 #include "../../../snacc.h"
 
 /* Function Prototypes */
-char* Code2UnivCodeStr PROTO((BER_UNIV_CODE code));
+const char* Code2UnivCodeStr PROTO((BER_UNIV_CODE code));
+const char* BasicType2UnivCodeStr(enum BasicTypeChoiceId);
 void PrintCAnyCode(FILE* src, FILE* hdr, CRules* r, ModuleList* mods, Module* m, int printEncoders, int printDecoders, int printPrinters, int printFree);
 void PrintCContentDecoder PROTO((FILE * src, FILE* hdr, CRules* r, Module* m, TypeDef* td, long int* longJmpVal));
 void PrintCContentEncoder PROTO((FILE * src, FILE* hdr, CRules* r, Module* m, TypeDef* td));

--- a/compiler/back-ends/c-gen/gen-dec.c
+++ b/compiler/back-ends/c-gen/gen-dec.c
@@ -631,7 +631,7 @@ static void PrintCSetDecodeCode PARAMS((src, td, parent, elmts, elmtLevel, total
 	enum BasicTypeChoiceId builtinType;
 	char* classStr;
 	char* formStr;
-	char* codeStr;
+	const char* codeStr;
 	int mandatoryCount = 0;
 	char tmpVarName[MAX_VAR_REF];
 	int stoleChoiceTags;
@@ -903,7 +903,7 @@ static void PrintCSeqDecodeCode PARAMS((src, td, parent, elmts, elmtLevel, total
 	enum BasicTypeChoiceId tmpTypeId;
 	char* classStr;
 	char* formStr;
-	char* codeStr;
+	const char* codeStr;
 	char tmpVarName[MAX_VAR_REF];
 	int stoleChoiceTags;
 	int inTailOptElmts = FALSE;
@@ -1325,7 +1325,7 @@ static void PrintCListDecoderCode PARAMS((src, td, list, elmtLevel, totalLevel, 
 	enum BasicTypeChoiceId builtinType;
 	char* classStr;
 	char* formStr;
-	char* codeStr;
+	const char* codeStr;
 	char tmpVarName[MAX_VAR_REF];
 	int stoleChoiceTags;
 	int initialTagLevel;
@@ -1498,7 +1498,7 @@ static void PrintCChoiceDecodeCode PARAMS((src, td, t, elmtLevel, totalLevel, ta
 	enum BasicTypeChoiceId builtinType;
 	char* classStr;
 	char* formStr;
-	char* codeStr;
+	const char* codeStr;
 	char tmpVarName[MAX_VAR_REF];
 	char choiceIdVarName[MAX_VAR_REF];
 	int stoleChoiceTags;

--- a/compiler/back-ends/c-gen/gen-enc.c
+++ b/compiler/back-ends/c-gen/gen-enc.c
@@ -274,7 +274,7 @@ void PrintCEncoder PARAMS((src, hdr, r, m, td), FILE* src _AND_ FILE* hdr _AND_ 
 	int tagLen;
 	int stoleChoiceTags;
 	EncRulesType* encoding;
-	char* pszCode = NULL;
+	const char* pszCode = NULL;
 
 	ctdi = td->cTypeDefInfo;
 	if (!ctdi->genEncodeRoutine)

--- a/compiler/back-ends/tag-util.c
+++ b/compiler/back-ends/tag-util.c
@@ -64,6 +64,7 @@
 #include "c-gen/util.h"
 #include "tag-util.h"
 #include <memory.h>
+#include <assert.h>
 
 /*
  * returns the tags for the given type (stops at next type definition).
@@ -403,7 +404,7 @@ char* Form2FormStr PARAMS((form), BER_FORM form)
 	}
 } /* Form2FormStr */
 
-char* Code2UnivCodeStr PARAMS((code), BER_UNIV_CODE code)
+const char* Code2UnivCodeStr PARAMS((code), BER_UNIV_CODE code)
 {
 	// static char UNKNOWN_TAG_CODE[10];
 
@@ -577,10 +578,10 @@ int CmpTags PARAMS((a, b), Type* a _AND_ Type* b)
 
 //
 //
-char* DetermineCode(Tag* tag, int* ptagLen, int bJustIntegerFlag)
+const char* DetermineCode(Tag* tag, int* ptagLen, int bJustIntegerFlag)
 {
 	static char retstring[5];
-	char* codeStr = NULL;
+	const char* codeStr = NULL;
 	int iValue = 500; // WILL indicate a problem on source creation...
 
 	if (tag->valueRef == NULL)
@@ -631,3 +632,57 @@ char* DetermineCode(Tag* tag, int* ptagLen, int bJustIntegerFlag)
 	} // END IF tag->valueRef
 	return (codeStr);
 } // END DetermineCode(...)
+
+const char* BasicType2UnivCodeStr(enum BasicTypeChoiceId choice)
+{
+	switch (choice)
+	{
+		case BASICTYPE_BOOLEAN:
+			return "BOOLEAN_TAG_CODE";
+		case BASICTYPE_INTEGER:
+			return "INTEGER_TAG_CODE";
+		case BASICTYPE_BITSTRING:
+			return "BITSTRING_TAG_CODE";
+		case BASICTYPE_OCTETSTRING:
+			return "OCTETSTRING_TAG_CODE";
+		case BASICTYPE_NULL:
+			return "NULLTYPE_TAG_CODE";
+		case BASICTYPE_OID:
+			return "OID_TAG_CODE";
+		case BASICTYPE_REAL:
+			return "REAL_TAG_CODE";
+		case BASICTYPE_ENUMERATED:
+			return "ENUM_TAG_CODE";
+		case BASICTYPE_SEQUENCE:
+			return "SEQ_TAG_CODE";
+		case BASICTYPE_SET:
+			return "SET_TAG_CODE";
+		case BASICTYPE_NUMERIC_STR:
+			return "NUMERICSTRING_TAG_CODE";
+		case BASICTYPE_PRINTABLE_STR:
+			return "PRINTABLESTRING_TAG_CODE";
+		case BASICTYPE_VIDEOTEX_STR:
+			return "VIDEOTEXSTRING_TAG_CODE";
+		case BASICTYPE_IA5_STR:
+			return "IA5STRING_TAG_CODE";
+		case BASICTYPE_UTCTIME:
+			return "UTCTIME_TAG_CODE";
+		case BASICTYPE_GENERALIZEDTIME:
+			return "GENERALIZEDTIME_TAG_CODE";
+		case BASICTYPE_GRAPHIC_STR:
+			return "GRAPHICSTRING_TAG_CODE";
+		case BASICTYPE_VISIBLE_STR:
+			return "VISIBLESTRING_TAG_CODE";
+		case BASICTYPE_GENERAL_STR:
+			return "GENERALSTRING_TAG_CODE";
+		case BASICTYPE_UNIVERSAL_STR:
+			return "UNIVERSALSTRING_TAG_CODE";
+		case BASICTYPE_BMP_STR:
+			return "BMPSTRING_TAG_CODE";
+		case BASICTYPE_UTF8_STR:
+			return "UTF8STRING_TAG_CODE";
+		default:
+			assert(0);
+			return NULL;
+	}
+}

--- a/compiler/back-ends/tag-util.h
+++ b/compiler/back-ends/tag-util.h
@@ -42,6 +42,7 @@ int CountTags PROTO((Type * t));
 unsigned long int TagByteLen PROTO((unsigned long int tagCode));
 char* Class2ClassStr PROTO((int _class)); /* class defined in asn1module.h */
 char* Form2FormStr PROTO((BER_FORM form));
-char* Code2UnivCodeStr PROTO((BER_UNIV_CODE code));
+const char* Code2UnivCodeStr PROTO((BER_UNIV_CODE code));
+const char* BasicType2UnivCodeStr PROTO((enum BasicTypeChoiceId choice));
 int CmpTags PROTO((Type * a, Type* b));
-char* DetermineCode PROTO((Tag * tag, int* ptagLen, int bJustIntegerFlag));
+const char* DetermineCode PROTO((Tag * tag, int* ptagLen, int bJustIntegerFlag));

--- a/compiler/core/snacc-validators.c
+++ b/compiler/core/snacc-validators.c
@@ -1048,7 +1048,7 @@ bool ValidateOptionals(ModuleList* allMods)
 					iErrorCounter = 0;
 				}
 
-				if (nError & VALIDATE_OPTIONALS_NO_MIXED_OPTIONALS && nError & VALIDATE_OPTIONALS_NO_EXPLICIT_OPTIONALS)
+				if (nError & VALIDATE_OPTIONALS_NO_MIXED_OPTIONALS)
 					fprintf(stderr, "- %s contains explicit and implicit optionals, use only implicit (with number)\n", td->definedName);
 				else if (nError & VALIDATE_OPTIONALS_NO_EXPLICIT_OPTIONALS)
 					fprintf(stderr, "- %s contains explicit optionals, use only implicit (with number)\n", td->definedName);

--- a/compiler/core/snacc.c
+++ b/compiler/core/snacc.c
@@ -239,7 +239,7 @@ void Usage PARAMS((prgName, fp), char* prgName _AND_ FILE* fp)
 #endif
 	fprintf(fp, "  -noprivate   do not generate code that is marked as private\n");
 	fprintf(fp, "  -nodeprecated   do not generate code that is marked as deprecated (any date)\n");
-	fprintf(fp, "  -nodeprecated:[Day.Month.Year]  do not generate code that has been marked deprecated prior to this date\n");
+	fprintf(fp, "  -nodeprecated:Day.Month.Year  do not generate code that has been marked deprecated prior to this date\n");
 	fprintf(fp, "  -ValidationLevel n - Sets a specific validation rule set for the asn1 files. Default is that all of the following checks are applied\n");
 	fprintf(fp, "   0 no validation\n");
 	fprintf(fp, "   1 Validates that operationIDs are not used twice\n");
@@ -248,6 +248,8 @@ void Usage PARAMS((prgName, fp), char* prgName _AND_ FILE* fp)
 	fprintf(fp, "   8 Validates that all sequences contain ... to allow extending them (@deprecated are not validated)\n");
 	fprintf(fp, "   16 Validates that only allow types from the esnacc_whiteliste.txt are used (@deprecated are not validated)\n");
 	fprintf(fp, "   32 Ensure that invokes are specified with argument, result and error where events only consists of an argument (@deprecated are not validated)\n");
+	fprintf(fp, "   64 Ensure that optional parameters are not encoded implicit (context specific, with number) and explicit (without) in the same object (@deprecated are not validated)\n");
+	fprintf(fp, "   128 Ensure that optional parameters are always encoded implicit and never explicit (@deprecated are not validated)\n");
 	fprintf(fp, "  -h   prints this msg\n");
 	fprintf(fp, "  -P   print the parsed ASN.1 modules to stdout from their parse trees\n");
 	fprintf(fp, "       (helpful debugging)\n");


### PR DESCRIPTION
- Validation allows to complain about using mixed optionals, explicit (without number) and implicit (with number)
- Validation allows to complain about using explicit (without number) optionals
- While decoding a BER encoded object we allow that an explicitly encoded optional is decoded with an implicit and vice versa
 - This is especially needed if we want to convert an object that contains only one explicit optional into a list of optionals that are then encoded / decoded all implicitly