### PR TITLE
BUILDSYS-365: fixed

### DIFF
--- a/compiler/core/cpp_helper.cpp
+++ b/compiler/core/cpp_helper.cpp
@@ -3,6 +3,7 @@
 #include "../../c-lib/include/asn-incl.h"
 #include <filesystem>
 #include <string>
+#include <cstring> // -> MingW, Clang, GCC
 #include <regex>
 #include <chrono>
 #include <thread>

--- a/compiler/core/snacc.c
+++ b/compiler/core/snacc.c
@@ -1129,7 +1129,12 @@ Module* ParseAsn1File(const char* fileName, short ImportFlag, int parseComments)
 		}
 		unsigned char szFileType[3] = {0};
 #ifdef _WIN32
+    #ifdef _MSC_VER
 		fread_s(szFileType, 3, sizeof(char), 3, fPtr);
+    #else
+        // MingW, Clang, GCC
+        fread(szFileType, sizeof(char), 3, fPtr);
+    #endif
 #else
 		fread(szFileType, sizeof(char), 3, fPtr);
 #endif


### PR DESCRIPTION
Compile Errors on Windows with MingW and on WSL with GCC