### PR TITLE
Cpp lib platform fixes

### DIFF
--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -195,7 +195,7 @@ public:
 	 *  bFlushEveryWrite - true flushes every write operation (ideal for debugging), false to let the os decide when to flush
 	 *
 	 *  returns NO_ERROR on success (logfile opened, logfile closed, nothing to do) or an error value */
-	int ConfigureFileLogging(const wchar_t* szPath, const bool bAppend = true, const bool bFlushEveryWrite = false);
+	int ConfigureFileLogging(const char* szPath, const bool bAppend = true, const bool bFlushEveryWrite = false);
 
 	/* Retrieve the log level - do we need to log something */
 	virtual SNACC::EAsnLogLevel GetLogLevel(const bool bOutbound) = 0;
@@ -256,8 +256,8 @@ public:
 	 * pInvoke - the invoke payload (it is put into a ROSEMessage in the function)
 	 * pResponse - the response payload (is handled afterwards in the HandleInvokeResult method
 	 * szOperationName - the operationName (for logging purposes)
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don´t care about the result))
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don´t care about the result))
+	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (donï¿½t care about the result))
+	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (donï¿½t care about the result))
 	 * pCtx - contextual data for the invoke
 	 */
 	virtual long SendInvoke(SNACC::ROSEInvoke* pinvoke, SNACC::ROSEMessage** pResponse, const char* szOperationName, int iTimeout = -1, SnaccInvokeContext* pCtx = nullptr) override;

--- a/cpp-lib/include/asn-incl.h
+++ b/cpp-lib/include/asn-incl.h
@@ -861,7 +861,12 @@ public:
 	}
 
 	operator AsnIntType() const;
+
+#ifdef WIN32
 	long long GetLongLong() const;
+#else
+    SJson::Int64 GetLongLong() const;
+#endif
 
 	bool operator==(AsnIntType o) const;
 	bool operator!=(AsnIntType o) const
@@ -892,7 +897,12 @@ public:
 
 	void Set(const unsigned char* str, size_t len, bool unsignedFlag = true);
 	void Set(AsnIntType i);
+
+#ifdef WIN32
 	void Set(long long i);
+#else
+    void Set(SJson::Int64 i);
+#endif
 
 	AsnLen BEnc(AsnBuf& b) const override;
 	void BDec(const AsnBuf& b, AsnLen& bytesDecoded) override;

--- a/cpp-lib/include/asn-incl.h
+++ b/cpp-lib/include/asn-incl.h
@@ -898,11 +898,8 @@ public:
 	void Set(const unsigned char* str, size_t len, bool unsignedFlag = true);
 	void Set(AsnIntType i);
 
-#ifdef WIN32
 	void Set(long long i);
-#else
     void Set(SJson::Int64 i);
-#endif
 
 	AsnLen BEnc(AsnBuf& b) const override;
 	void BDec(const AsnBuf& b, AsnLen& bytesDecoded) override;

--- a/cpp-lib/include/asn-incl.h
+++ b/cpp-lib/include/asn-incl.h
@@ -899,7 +899,11 @@ public:
 	void Set(AsnIntType i);
 
 	void Set(long long i);
+
+    #ifndef WIN32
+    // With Win32 SJson::Int64 is the same as long long
     void Set(SJson::Int64 i);
+    #endif
 
 	AsnLen BEnc(AsnBuf& b) const override;
 	void BDec(const AsnBuf& b, AsnLen& bytesDecoded) override;

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -1416,19 +1416,28 @@ long SnaccROSEBase::DecodeInvoke(SNACC::ROSEMessage* pInvokeMessage, SNACC::AsnT
 	return lRoseResult;
 }
 
-int SnaccROSEBase::ConfigureFileLogging(const wchar_t* szPath, const bool bAppend /*= true*/, const bool bFlushEveryWrite /* = false */)
+int SnaccROSEBase::ConfigureFileLogging(const char* szPath, const bool bAppend /*= true*/, const bool bFlushEveryWrite /* = false */)
 {
 	std::lock_guard<std::mutex> lock(m_mtxLogFile);
 
-	if (szPath && wcslen(szPath) && !m_pAsnLogFile)
+	if (szPath && strlen(szPath) && !m_pAsnLogFile)
 	{
 		m_bFlushEveryWrite = bFlushEveryWrite;
-		const wchar_t* szMode = bAppend ? L"a" : L"w";
-		m_pAsnLogFile = _wfsopen(szPath, szMode, _SH_DENYWR);
+		const char* szMode = bAppend ? "a" : "w";
+#ifdef WIN32
+		m_pAsnLogFile = _fsopen(szPath, szMode, _SH_DENYWR);
+#else
+        m_pAsnLogFile = fopen(szPath, szMode);
+#endif
 		if (!m_pAsnLogFile)
 		{
 			int iErr = 0;
-			_get_errno(&iErr);
+#ifdef WIN32
+    _get_errno(&iErr);
+#else
+    iErr = errno;
+#endif
+
 			return iErr;
 		}
 		else
@@ -1437,7 +1446,7 @@ int SnaccROSEBase::ConfigureFileLogging(const wchar_t* szPath, const bool bAppen
 			m_bAsnLogFileContainsData = ftell(m_pAsnLogFile) > 0;
 		}
 	}
-	else if ((!szPath || !wcslen(szPath)) && m_pAsnLogFile)
+	else if ((!szPath || !strlen(szPath)) && m_pAsnLogFile)
 	{
 		fclose(m_pAsnLogFile);
 		m_pAsnLogFile = nullptr;
@@ -1451,7 +1460,7 @@ void SnaccROSEBase::PrintJSONToLog(const bool bOutbound, const bool bError, cons
 	if (!m_pAsnLogFile)
 		return;
 
-	// Die ASN.1-Funktionen können auch aus verschiedenen Threads gerufen werden.
+	// Die ASN.1-Funktionen kï¿½nnen auch aus verschiedenen Threads gerufen werden.
 	// Das Schreiben in die roseout.log muss aber damit serialisiert werden.
 	// Der Lock sollte nicht schaden, da nur die Datei selbst gelockt wird und kein anderes Objekt (PAIM-1732).
 	std::lock_guard<std::mutex> lock(m_mtxLogFile);
@@ -1467,7 +1476,11 @@ void SnaccROSEBase::PrintJSONToLog(const bool bOutbound, const bool bError, cons
 		auto duration = currentTime.time_since_epoch();
 		auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(duration) % 1000;
 		std::tm timeInfo;
+#ifdef WIN32
 		gmtime_s(&timeInfo, &currentTimeT);
+#else
+        gmtime_r(&currentTimeT, &timeInfo);
+#endif
 		std::ostringstream strTime;
 		strTime << std::put_time(&timeInfo, "%Y-%m-%dT%H:%M:%S.");
 		strTime << std::setfill('0') << std::setw(3) << milliseconds.count();

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -1425,7 +1425,12 @@ int SnaccROSEBase::ConfigureFileLogging(const char* szPath, const bool bAppend /
 		m_bFlushEveryWrite = bFlushEveryWrite;
 		const char* szMode = bAppend ? "a" : "w";
 #ifdef WIN32
+    #ifdef _MSC_VER
 		m_pAsnLogFile = _fsopen(szPath, szMode, _SH_DENYWR);
+    #else
+        // MingW, Clang, GCC
+        m_pAsnLogFile = fopen(szPath, szMode);
+    #endif
 #else
         m_pAsnLogFile = fopen(szPath, szMode);
 #endif

--- a/cpp-lib/src/asn-int.cpp
+++ b/cpp-lib/src/asn-int.cpp
@@ -741,10 +741,12 @@ void AsnInt::Set(AsnIntType iIn)
 	storeDERInteger(cTmp, sizeof(iIn), (iIn >= 0));
 }
 
+#ifndef WIN32
 void AsnInt::Set(SJson::Int64 iIn)
 {
     Set((long long)iIn);
 }
+#endif
 
 void AsnInt::Set(long long iIn)
 {

--- a/cpp-lib/src/asn-int.cpp
+++ b/cpp-lib/src/asn-int.cpp
@@ -741,11 +741,12 @@ void AsnInt::Set(AsnIntType iIn)
 	storeDERInteger(cTmp, sizeof(iIn), (iIn >= 0));
 }
 
-#ifdef WIN32
-void AsnInt::Set(long long iIn)
-#else
 void AsnInt::Set(SJson::Int64 iIn)
-#endif
+{
+    Set((long long)iIn);
+}
+
+void AsnInt::Set(long long iIn)
 {
 	long long iTmp;
 	unsigned char cTmp[sizeof(iIn)];

--- a/cpp-lib/src/asn-int.cpp
+++ b/cpp-lib/src/asn-int.cpp
@@ -686,7 +686,11 @@ AsnInt::operator AsnIntType() const
 	return iResult;
 }
 
+#ifdef WIN32
 long long AsnInt::GetLongLong() const
+#else
+SJson::Int64 AsnInt::GetLongLong() const
+#endif
 {
 	FUNC("AsnInt::operator long long");
 
@@ -737,7 +741,11 @@ void AsnInt::Set(AsnIntType iIn)
 	storeDERInteger(cTmp, sizeof(iIn), (iIn >= 0));
 }
 
+#ifdef WIN32
 void AsnInt::Set(long long iIn)
+#else
+void AsnInt::Set(SJson::Int64 iIn)
+#endif
 {
 	long long iTmp;
 	unsigned char cTmp[sizeof(iIn)];

--- a/cpp-lib/src/snaccexcept.cpp
+++ b/cpp-lib/src/snaccexcept.cpp
@@ -2,6 +2,8 @@
 //
 //
 #include "../include/snaccexcept.h"
+#include <memory.h>
+#include <cstring>
 
 namespace SNACC
 {


### PR DESCRIPTION
Only remarkable thing: On Linux there is no fopen()-Version that takes wchar_t as parameter; after checking the code, wchar_t in this place is just not needed, so switched back to char*.
Maybe the better fix would be using the C++-IO Functions, but i didnt want to change the business logic for compiler errors when not needed at this point.
