### PR TITLE
EG-1108 Changed the way we decode an optional asn any.

### DIFF
--- a/cpp-lib/src/asn-any.cpp
+++ b/cpp-lib/src/asn-any.cpp
@@ -559,15 +559,6 @@ void AsnAny::BDec(const AsnBuf& b, AsnLen& bytesDecoded)
 
 void AsnAny::BDecContent(const AsnBuf& b, AsnTag tag, AsnLen elmtLen, AsnLen& bytesDecoded)
 {
-	if (TAG_IS_CNTX(tag) && elmtLen > 2)
-	{
-		// Special
-		// If we have an indexed optional any, we cannot determine the type using the schema (The type is any)
-		// In this case the details about the structure (is it a sequence a string etc) are burried within
-		// the object and the reader is now on the position of the any. So we need to read the following tag and len information
-		tag = BDecTag(b, bytesDecoded);
-		elmtLen = BDecLen(b, bytesDecoded);
-	}
 	const auto tagLen = BytesInTag(tag);
 	const auto elementLen = BytesInLen(elmtLen);
 	const auto headerLen = tagLen + elementLen;

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "6.0.19"
-#define VERSION_RC 6, 0, 19
-#define RELDATE "20.09.2024"
+#define VERSION "6.0.20"
+#define VERSION_RC 6, 0, 20
+#define RELDATE "14.11.2024"
 
 #endif // VERSION_H


### PR DESCRIPTION
The constructed optional attributes need to get removed before passing the content to the any as these belong to the parent structure, not to the any itself