### PR TITLE
BUILDSYS-516 Remove check whether date is <10. 

### DIFF
--- a/cpp-lib/src/asn-systemtime.cpp
+++ b/cpp-lib/src/asn-systemtime.cpp
@@ -53,9 +53,12 @@ bool VariantTimeToSystemTimeWithMilliseconds(const DATE& dVariantTime, SYSTEMTIM
 
 std::string DateToISO8601(DATE dt)
 {
+	// This is absolutly wierd to discard values based on a random chosen value.
+	// We convert everything into a matching string no matter which value it has!
+	//
 	// we discard such old data immediately
-	if (dt < 10)
-		return "";
+	// if (dt < 10)
+	//	return "";
 
 	// 2012-04-23T18:25:43.511Z
 	// 2012-04-23T18:25:43.500Z		// Zeros at the end are technically superfluous, but make them easier to read.

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "6.0.24"
-#define VERSION_RC 6, 0, 24
-#define RELDATE "27.02.2025"
+#define VERSION "6.0.25"
+#define VERSION_RC 6, 0, 25
+#define RELDATE "18.03.2025"
 
 #endif // VERSION_H


### PR DESCRIPTION
Every date value has it´s corresponding ISO8601 value. Check is not needed and leads to broken json values as the result is an empty string and not a valid iso8601 time