### PR TITLE
UCAAS-1070 fix pdbs are not properly created

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.20...4.1)
 project(esnacc_cmake) #  LANGUAGES CXX) - would interpret all files as C++
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 set(CMAKE_DEBUG_POSTFIX "d")
 
 # Root-level helper

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "5.1.5"
-#define VERSION_RC 5, 1, 5
-#define RELDATE "18.09.2025"
+#define VERSION "5.1.6"
+#define VERSION_RC 5, 1, 6
+#define RELDATE "06.10.2025"
 
 #endif // VERSION_H


### PR DESCRIPTION
after reconfiguring cmake_minimum_required to the version range 3.2 - 4.1