### PR TITLE
UCAAS-1333 refactor ROSE telemetry, invoke context, and generated call flow

### DIFF
--- a/compiler/back-ends/c++-gen/cxxmultipleconstraints.c
+++ b/compiler/back-ends/c++-gen/cxxmultipleconstraints.c
@@ -54,7 +54,6 @@ int BasicTypeString_LISTS PARAMS((hdr, src, scList, iSCPresent, curr, currS_type
 		{
 			switch (currS_type->a.single->choiceId)
 			{
-
 				case SUBTYPEVALUE_VALUERANGE:
 					{
 						break;
@@ -67,7 +66,6 @@ int BasicTypeString_LISTS PARAMS((hdr, src, scList, iSCPresent, curr, currS_type
 
 				case SUBTYPEVALUE_SIZECONSTRAINT:
 					{
-
 						if (currS_type->choiceId == SUBTYPE_OR)
 						{
 							pTmpnode = currS_type->a.single->a.sizeConstraint->a.or->first;
@@ -494,7 +492,7 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i), FILE*
 				else
 				{
 					fprintf(src, "		sizeVRList = 0;\n");
-					fprintf(src, "		return NULL;\n");
+					fprintf(src, "		return nullptr;\n");
 				}
 
 				fprintf(src, "}\n\n");
@@ -629,7 +627,6 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i), FILE*
 
 				if (s_type->choiceId == SUBTYPE_AND)
 				{
-
 					and_curr = s_type->a.and->first;
 					while (and_curr)
 					{
@@ -716,7 +713,7 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i), FILE*
 				else
 				{
 					fprintf(src, "	sizeList = 0;\n");
-					fprintf(src, "	return NULL;\n");
+					fprintf(src, "	return nullptr;\n");
 				}
 				fprintf(src, "}\n\n\n");
 
@@ -746,7 +743,6 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i), FILE*
 
 				if (i != 3 && i != 0)
 				{
-
 					/* Last we declare an instance of the internal class we */
 					/*   just created                                       */
 					if (i == 0)
@@ -887,7 +883,7 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i), FILE*
 				else
 				{
 					fprintf(src, "	sizeList = 0;\n");
-					fprintf(src, "	return NULL;\n");
+					fprintf(src, "	return nullptr;\n");
 				}
 
 				fprintf(src, "}\n\n\n");
@@ -1036,7 +1032,7 @@ int PrintCxxMultiConstraintOrHandler PARAMS((hdr, src, definedName, e, i), FILE*
 				else
 				{
 					fprintf(src, "	sizeList = 0;\n");
-					fprintf(src, "	return NULL;\n");
+					fprintf(src, "	return nullptr;\n");
 				}
 
 				fprintf(src, "}\n\n\n");

--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -57,7 +57,7 @@ const char* getAccessor(const AsnBool isPtr)
 int constraints_flag;
 long lconstraintvar = 0;
 
-int genCodeCPPPrintStdAfxInclude = 0;
+int genCodeCPPPrintPCHInclude = 0;
 
 long longJmpValG = -100;
 int printTypesG = 0;
@@ -312,7 +312,7 @@ void PrintInit(FILE* hdr, FILE* src, Module* m, TypeDef* td, Type* t)
 					fprintf(src, "#if TCL\n");
 					fprintf(src, "\t%s = new %s;\n", e->type->cxxTypeRefInfo->fieldName, e->type->cxxTypeRefInfo->className);
 					fprintf(src, "#else\n");
-					fprintf(src, "\t%s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+					fprintf(src, "\t%s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 					fprintf(src, "#endif // TCL\n");
 #else
 					/* Default member initialization is a work in progress for eSNACC 1.6
@@ -370,7 +370,7 @@ void PrintInit(FILE* hdr, FILE* src, Module* m, TypeDef* td, Type* t)
 					else
 					{
 						if (e->type->optional)
-							fprintf(src, "\t%s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+							fprintf(src, "\t%s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 						else
 							fprintf(src, "\t%s = new %s();\n", e->type->cxxTypeRefInfo->fieldName, e->type->cxxTypeRefInfo->className);
 					}
@@ -436,7 +436,7 @@ void PrintClear(FILE* hdr, FILE* src, Module* m, TypeDef* td, Type* t)
 				fprintf(src, "\tif (%s)\n", e->type->cxxTypeRefInfo->fieldName);
 				fprintf(src, "\t{\n");
 				fprintf(src, "\t\tdelete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "\t\t%s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "\t\t%s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 				fprintf(src, "\t}\n");
 			}
 			else if (!e->type->cxxTypeRefInfo->isPtr && ((tmpTypeId == BASICTYPE_CHOICE) || (tmpTypeId == BASICTYPE_SET) || (tmpTypeId == BASICTYPE_SEQUENCE)))
@@ -458,7 +458,7 @@ void PrintClear(FILE* hdr, FILE* src, Module* m, TypeDef* td, Type* t)
 			{
 				fprintf(src, "\tif(%s)\n", e->type->cxxTypeRefInfo->fieldName);
 				fprintf(src, "\t\tdelete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "\t\t%s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "\t\t%s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 			}
 			else if (!e->type->cxxTypeRefInfo->isPtr && ((tmpTypeId == BASICTYPE_CHOICE) || (tmpTypeId == BASICTYPE_SET) || (tmpTypeId == BASICTYPE_SEQUENCE)))
 			{
@@ -743,7 +743,7 @@ static void PrintAssignmentOperator(FILE* hdr, FILE* src, Module* m, Type* t, Ty
 					fprintf(src, "\t\telse if (%s)\n", e->type->cxxTypeRefInfo->fieldName);
 					fprintf(src, "\t\t{\n");
 					fprintf(src, "\t\t\tdelete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-					fprintf(src, "\t\t\t%s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+					fprintf(src, "\t\t\t%s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 					fprintf(src, "\t\t}\n");
 				}
 				else
@@ -1138,9 +1138,9 @@ static bool PrintROSEOnInvoke(FILE* hdr, int bEvents, Module* mod, ValueDef* vd,
 			// there is a result -> it is a Funktion
 			// Header
 			if (pszError)
-				fprintf(hdr, "\tvirtual InvokeResult OnInvoke_%s(%s* argument, %s* result, %s* error, SnaccInvokeContext* cxt) { return InvokeResult::returnReject; }\n", vd->definedName, pszArgument, pszResult, pszError);
+				fprintf(hdr, "\tvirtual InvokeResult OnInvoke_%s(%s* argument, %s* result, %s* error, SnaccInvokeContext& ctx) { return InvokeResult::returnReject; }\n", vd->definedName, pszArgument, pszResult, pszError);
 			else
-				fprintf(hdr, "\tvirtual InvokeResult OnInvoke_%s(%s* argument, %s* result, SnaccInvokeContext* cxt) { return InvokeResult::returnReject; }\n", vd->definedName, pszArgument, pszResult);
+				fprintf(hdr, "\tvirtual InvokeResult OnInvoke_%s(%s* argument, %s* result, SnaccInvokeContext& ctx) { return InvokeResult::returnReject; }\n", vd->definedName, pszArgument, pszResult);
 		}
 		else if (!pszResult && bEvents)
 		{
@@ -1177,50 +1177,42 @@ static void PrintROSEOnInvokeswitchCase(FILE* src, int bEvents, Module* mod, Val
 			fprintf(src, "\t\t{\n");
 
 			fprintf(src, "\t\t\t%s argument;\n", pszArgument);
-			if (pszResult)
-				fprintf(src, "\t\t\t%s result;\n", pszResult);
-			if (pszError)
-				fprintf(src, "\t\t\t%s error;\n", pszError);
+			fprintf(src, "\t\t\tlRoseResult = pBase->DecodeInvoke(pMsg, &argument);\n");
+			fprintf(src, "\t\t\tif (lRoseResult == ROSE_NOERROR)\n");
+			const bool bIsDeprecated = IsDeprecatedFlaggedOperation(mod, vd->definedName);
+			const bool bIsMultiLine = bIsDeprecated || pszResult;
+			if (bIsMultiLine)
+				fprintf(src, "\t\t\t{\n");
 
-			fprintf(src, "\n\t\t\tlRoseResult = pBase->DecodeInvoke(pMsg, &argument);\n");
-			fprintf(src, "\t\t\tif (lRoseResult != ROSE_NOERROR)\n");
-			fprintf(src, "\t\t\t\tbreak;\n\n");
-
-			if (IsDeprecatedFlaggedOperation(mod, vd->definedName))
+			if (bIsDeprecated)
 			{
-				fprintf(src, "\t\t\t// This method has been flagged deprecated\n");
+				fprintf(src, "\t\t\t\t// This method has been flagged deprecated\n");
 				asnoperationcomment comment;
 				GetOperationComment_UTF8(mod->moduleName, vd->definedName, &comment);
-				fprintf(src, "\t\t\tSNACCDeprecated::DeprecatedASN1Method(%lld, \"%s\", \"%s\", SNACCDeprecatedNotifyCallDirection::in%s);\n\n", comment.i64Deprecated, mod->moduleName, vd->definedName, pszResult ? ", cxt" : "");
+				fprintf(src, "\t\t\t\tSNACCDeprecated::DeprecatedASN1Method(%lld, \"%s\", \"%s\", SNACCDeprecatedNotifyCallDirection::in, ctx);\n", comment.i64Deprecated, mod->moduleName, vd->definedName);
 			}
-
 			if (pszResult)
 			{
+				fprintf(src, "\t\t\t\t%s result;\n", pszResult);
 				if (pszError)
-					fprintf(src, "\t\t\tswitch (pInt->OnInvoke_%s(&argument, &result, &error, cxt))\n", vd->definedName);
+				{
+					fprintf(src, "\t\t\t\t%s error;\n", pszError);
+					fprintf(src, "\t\t\t\tauto invokeResult = pInt->OnInvoke_%s(&argument, &result, &error, ctx);\n", vd->definedName);
+					fprintf(src, "\t\t\t\tlRoseResult = pBase->HandleOnInvokeResult(invokeResult, pInvoke, ctx, strResponseData, &result, &error);\n");
+				}
 				else
-					fprintf(src, "\t\t\tswitch (pInt->OnInvoke_%s(&argument, &result, cxt))\n", vd->definedName);
-				fprintf(src, "\t\t\t{\n");
-				fprintf(src, "\t\t\tcase InvokeResult::returnResult:\n");
-				fprintf(src, "\t\t\t\tlRoseResult = pBase->SendResult(pMsg->invoke, &result);\n");
-				fprintf(src, "\t\t\t\tbreak;\n");
-				fprintf(src, "\t\t\tcase InvokeResult::returnError:\n");
-				if (pszError)
-					fprintf(src, "\t\t\t\tlRoseResult = pBase->SendError(pMsg->invoke, &error);\n");
-				else
-					fprintf(src, "\t\t\t\tlRoseResult = pBase->SendError(pMsg->invoke, NULL);\n");
-
-				fprintf(src, "\t\t\t\tbreak;\n");
-				fprintf(src, "\t\t\tdefault:\n");
-				fprintf(src, "\t\t\t\tlRoseResult = cxt->lRejectResult ? cxt->lRejectResult : ROSE_REJECT_FUNCTIONMISSING;\n");
-				fprintf(src, "\t\t\t\tbreak;\n");
-				fprintf(src, "\t\t\t}\n");
+				{
+					fprintf(src, "\t\t\t\tauto invokeResult = pInt->OnInvoke_%s(&argument, &result, ctx);\n", vd->definedName);
+					fprintf(src, "\t\t\t\tlRoseResult = pBase->HandleOnInvokeResult(invokeResult, pInvoke, ctx, strResponseData, &result);\n");
+				}
 			}
 			else
 			{
-				fprintf(src, "\t\t\tpInt->OnEvent_%s(&argument);\n", vd->definedName);
-				fprintf(src, "\t\t\tlRoseResult = ROSE_NOERROR;\n");
+				fprintf(src, "\t\t\t\tpInt->OnEvent_%s(&argument);\n", vd->definedName);
 			}
+			if (bIsMultiLine)
+				fprintf(src, "\t\t\t}\n");
+
 			fprintf(src, "\t\t}\n");
 			fprintf(src, "\t\tbreak;\n");
 		}
@@ -1350,55 +1342,43 @@ static bool PrintROSEInvoke(FILE* hdr, FILE* src, Module* m, int bEvents, ValueD
 			{
 				if (pszError)
 				{
-					fprintf(hdr, "\tlong Invoke_%s(%s* argument, %s* result, %s* error, int iTimeout = -1, SnaccInvokeContext* pCtx = 0);\n", vd->definedName, pszArgument, pszResult, pszError);
-					fprintf(src, "long %s::Invoke_%s(%s* argument, %s* result, %s* error, int iTimeout, SnaccInvokeContext* pCtx)\n", m->ROSEClassName, vd->definedName, pszArgument, pszResult, pszError);
+					fprintf(hdr, "\tlong Invoke_%s(%s* argument, %s* result, %s* error, int iTimeout = -1, std::shared_ptr<SnaccInvokeContext> pCtx = {});\n", vd->definedName, pszArgument, pszResult, pszError);
+					fprintf(src, "long %s::Invoke_%s(%s* argument, %s* result, %s* error, int iTimeout /*= -1*/, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)\n", m->ROSEClassName, vd->definedName, pszArgument, pszResult, pszError);
 				}
 				else
 				{
-					fprintf(hdr, "\tlong Invoke_%s(%s* argument, %s* result, int iTimeout = -1, SnaccInvokeContext* pCtx = 0);\n", vd->definedName, pszArgument, pszResult);
-					fprintf(src, "long %s::Invoke_%s(%s* argument, %s* result, int iTimeout, SnaccInvokeContext* pCtx)\n", m->ROSEClassName, vd->definedName, pszArgument, pszResult);
+					fprintf(hdr, "\tlong Invoke_%s(%s* argument, %s* result, int iTimeout = -1, std::shared_ptr<SnaccInvokeContext> pCtx = {});\n", vd->definedName, pszArgument, pszResult);
+					fprintf(src, "// default parameters: iTimeout = -1, pCtx = {}\n");
+					fprintf(src, "long %s::Invoke_%s(%s* argument, %s* result, int iTimeout /*= -1*/, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)\n", m->ROSEClassName, vd->definedName, pszArgument, pszResult);
 				}
 			}
 			else
 			{
-				fprintf(hdr, "\tlong Event_%s(%s* argument);\n", vd->definedName, pszArgument);
-				fprintf(src, "long %s::Event_%s(%s* argument)\n", m->ROSEClassName, vd->definedName, pszArgument);
+				fprintf(hdr, "\tlong Event_%s(%s* argument, std::shared_ptr<SnaccInvokeContext> pCtx = {});\n", vd->definedName, pszArgument);
+				fprintf(src, "// default parameters: pCtx = {}\n");
+				fprintf(src, "long %s::Event_%s(%s* argument, std::shared_ptr<SnaccInvokeContext> pCtx)\n", m->ROSEClassName, vd->definedName, pszArgument);
 			}
 
 			fprintf(src, "{\n");
-			fprintf(src, "\tROSEInvoke InvokeMsg;\n");
+			fprintf(src, "\tSnaccScopedInvokeMessage invokeMsg(");
 			if (pszResult)
-				fprintf(src, "\tInvokeMsg.invokeID = m_pSB->GetNextInvokeID();\n");
+				fprintf(src, "m_pSB->GetNextInvokeID(), OPID_%s, argument);\n", vd->definedName);
 			else
-				fprintf(src, "\tInvokeMsg.invokeID = 99999;\n");
-
-			fprintf(src, "\tInvokeMsg.operationID = OPID_%s;\n", vd->definedName);
-			fprintf(src, "\tInvokeMsg.argument = new AsnAny;\n");
-			fprintf(src, "\tInvokeMsg.argument->value = argument;\n\n");
-
-			if (pszResult)
-				fprintf(src, "\tROSEMessage* pResponseMsg = NULL;\n");
+				fprintf(src, "99999, OPID_%s, argument);\n", vd->definedName);
 
 			if (IsDeprecatedFlaggedOperation(m, vd->definedName))
 			{
+				fprintf(src, "\tpCtx = pCtx ? pCtx : m_pSB->CreateInvokeContext(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND, invokeMsg.GetPtr(), \"%s\"));\n", vd->definedName);
 				fprintf(src, "\t// This method has been flagged deprecated\n");
 				asnoperationcomment comment;
 				GetOperationComment_UTF8(m->moduleName, vd->definedName, &comment);
-				fprintf(src, "\tSNACCDeprecated::DeprecatedASN1Method(%lld, \"%s\", \"%s\", SNACCDeprecatedNotifyCallDirection::out%s);\n\n", comment.i64Deprecated, m->moduleName, vd->definedName, pszResult ? ", pCtx" : "");
+				fprintf(src, "\tSNACCDeprecated::DeprecatedASN1Method(%lld, \"%s\", \"%s\", SNACCDeprecatedNotifyCallDirection::out, *pCtx);\n", comment.i64Deprecated, m->moduleName, vd->definedName);
 			}
 
 			if (pszResult)
-			{
-				fprintf(src, "\tlong lRoseResult = m_pSB->SendInvoke(&InvokeMsg, &pResponseMsg, \"%s\", iTimeout, pCtx);\n", vd->definedName);
-				fprintf(src, "\tlRoseResult = m_pSB->HandleInvokeResult(lRoseResult, pResponseMsg, result, %s, pCtx);\n", pszError ? "error" : "nullptr");
-			}
+				fprintf(src, "\treturn m_pSB->SendInvoke(invokeMsg.GetPtr(), result, %s, \"%s\", iTimeout, pCtx);\n", pszError ? "error" : "nullptr", vd->definedName);
 			else
-				fprintf(src, "\tlong lRoseResult = m_pSB->SendEvent(&InvokeMsg, \"%s\");\n", vd->definedName);
-
-			fprintf(src, "\n\t// prevent auto deletion of argument\n");
-			fprintf(src, "\tInvokeMsg.argument->value = nullptr;\n\n");
-
-			fprintf(src, "\treturn lRoseResult;\n");
+				fprintf(src, "\treturn m_pSB->SendEvent(invokeMsg.GetPtr(), \"%s\", pCtx);\n", vd->definedName);
 
 			fprintf(src, "}\n");
 			fprintf(src, "\n");
@@ -4509,8 +4489,10 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	PrintHdrComment(hdr, m);
 	PrintHdrComment(hdrInterface, m);
 
-	if (genCodeCPPPrintStdAfxInclude)
-		fprintf(src, "#include \"stdafx.h\"\n");
+	if (genCodeCPPPrintPCHInclude == 2)
+		fprintf(src, "#include \"pch.h\"");
+	else if (genCodeCPPPrintPCHInclude)
+		fprintf(src, "#include \"stdafx.h\"");
 
 	PrintConditionalIncludeOpen(hdr, m->ROSEHdrFileName);
 	PrintConditionalIncludeOpen(hdrInterface, m->ROSEHdrInterfaceFileName);
@@ -4525,6 +4507,7 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	PrintSrcIncludes(src, mods, m);
 	fprintf(src, "#include \"%s\"\n", RemovePath(m->ROSEHdrFileName));
 	fprintf(src, "#include \"%s\"\n", RemovePath(m->ROSEHdrInterfaceFileName));
+	fprintf(src, "#include <utility>\n");
 	fprintf(src, "#include <%sSnaccROSEBase.h>\n", szCppHeaderIncludePath);
 	fprintf(src, "#include <%sSNACCROSE.h>\n", szCppHeaderIncludePath);
 	fprintf(src, "#include <%sSNACCDeprecated.h>\n", szCppHeaderIncludePath);
@@ -4599,13 +4582,13 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 
 	// generate the InvokeHandler
 	fprintf(hdr, "\t// The main Invoke Dispatcher\n");
-	fprintf(hdr, "\tstatic long OnInvoke(SNACC::ROSEMessage* pMsg, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext* cxt);\n", m->ROSEClassName);
-	fprintf(src, "long %s::OnInvoke(SNACC::ROSEMessage* pMsg, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext* cxt)\n", m->ROSEClassName, m->ROSEClassName);
+	fprintf(hdr, "\tstatic long OnInvoke(SNACC::ROSEMessage* pMsg, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext& ctx, std::string& strResponseData);\n", m->ROSEClassName);
+	fprintf(src, "long %s::OnInvoke(SNACC::ROSEMessage* pMsg, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext& ctx, std::string& strResponseData)\n", m->ROSEClassName, m->ROSEClassName);
 	fprintf(src, "{\n");
 	fprintf(src, "\tlong lRoseResult = ROSE_REJECT_UNKNOWNOPERATION;\n");
 	fprintf(src, "\n");
-	fprintf(src, "\t#ifndef ROSENOINVOKEDISPATCH\n");
-	fprintf(src, "\tswitch (pMsg->invoke->operationID)\n");
+	fprintf(src, "\tauto pInvoke = pMsg->invoke;\n");
+	fprintf(src, "\tswitch (pInvoke->operationID)\n");
 	fprintf(src, "\t{\n");
 
 	// Rose Interface class
@@ -4625,7 +4608,6 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	}
 
 	fprintf(src, "\t}\n");
-	fprintf(src, "\t#endif //#ifndef ROSENOINVOKEDISPATCH\n");
 	fprintf(src, "\treturn lRoseResult;\n");
 	fprintf(src, "}\n");
 	fprintf(src, "\n");
@@ -4759,7 +4741,9 @@ void PrintCxxCode(FILE* src, FILE* hdr, if_META(MetaNameStyle printMeta _AND_) i
 		free(szNumericDate);
 	}
 
-	if (genCodeCPPPrintStdAfxInclude)
+	if (genCodeCPPPrintPCHInclude == 2)
+		fprintf(src, "#include \"pch.h\"\n");
+	else if (genCodeCPPPrintPCHInclude)
 		fprintf(src, "#include \"stdafx.h\"\n");
 
 #if META
@@ -5878,7 +5862,7 @@ void PrintCxxChoiceDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* choice
 	fprintf(src, "{\n");
 	fprintf(src, "  ChoiceIdEnum newCid = (ChoiceIdEnum)_desc.choicebyname (membername);\n");
 	fprintf(src, "  if (newCid == -1)\n");
-	fprintf(src, "    return NULL;\n");
+	fprintf(src, "    return nullptr;\n");
 	fprintf(src, "  if (newCid == choiceId)\n");
 	fprintf(src, "  {\n");
 	fprintf(src, "    switch (choiceId)\n");
@@ -5889,7 +5873,7 @@ void PrintCxxChoiceDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* choice
 		fprintf(src, "        return %s;\n", e->type->cxxTypeRefInfo->fieldName);
 	}
 	fprintf(src, "      default:\n");
-	fprintf(src, "        return NULL;\n");
+	fprintf(src, "        return nullptr;\n");
 	fprintf(src, "    }\n");
 	fprintf(src, "  }\n");
 	fprintf(src, "  else\n");
@@ -5902,16 +5886,16 @@ void PrintCxxChoiceDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* choice
 	{
 		fprintf(src, "//        case %sCid:\n", e->type->cxxTypeRefInfo->fieldName);
 		fprintf(src, "//          delete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-		fprintf(src, "//          %s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+		fprintf(src, "//          %s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 		fprintf(src, "//          break;\n");
 	}
 	fprintf(src, "//        default:\n");
-	fprintf(src, "//          return NULL;\n");
+	fprintf(src, "//          return nullptr;\n");
 	fprintf(src, "//      }\n");
 	e = FIRST_LIST_ELMT(choice->basicType->a.choice);
 	fprintf(src, "      // simply delete any member, the virtual function table takes care of the rest:\n");
 	fprintf(src, "      delete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-	fprintf(src, "      %s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+	fprintf(src, "      %s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 	fprintf(src, "      switch (choiceId = newCid)\n");
 	fprintf(src, "      {\n");
 	FOR_EACH_LIST_ELMT(e, choice->basicType->a.choice)
@@ -5920,11 +5904,11 @@ void PrintCxxChoiceDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* choice
 		fprintf(src, "          return %s = new %s;\n", e->type->cxxTypeRefInfo->fieldName, e->type->cxxTypeRefInfo->className);
 	}
 	fprintf(src, "        default: // internal error!\n");
-	fprintf(src, "          return NULL;\n");
+	fprintf(src, "          return nullptr;\n");
 	fprintf(src, "      }\n");
 	fprintf(src, "    }\n");
 	fprintf(src, "    else\n");
-	fprintf(src, "      return NULL;\n");
+	fprintf(src, "      return nullptr;\n");
 	fprintf(src, "  }\n");
 	fprintf(src, "}\n\n");
 
@@ -6063,7 +6047,7 @@ void PrintCxxSeqDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* seq, Modu
 		else
 			fprintf(src, "    return &%s;\n", e->type->cxxTypeRefInfo->fieldName);
 	}
-	fprintf(src, "  return NULL;\n");
+	fprintf(src, "  return nullptr;\n");
 	fprintf(src, "}\n\n");
 
 #if TCL
@@ -6217,7 +6201,7 @@ void PrintCxxSeqDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* seq, Modu
 				fprintf(src, "    if (!present)\n");
 				fprintf(src, "    {\n");
 				fprintf(src, "      delete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "      %s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "      %s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 				fprintf(src, "    }\n");
 				fprintf(src, "  }\n");
 			}
@@ -6242,7 +6226,7 @@ void PrintCxxSeqDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* seq, Modu
 			if (e->type->optional || e->type->defaultVal)
 			{
 				fprintf(src, "        delete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "        %s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "        %s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 			}
 			else
 			{
@@ -6325,7 +6309,7 @@ void PrintCxxSetDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* set, Modu
 		else
 			fprintf(src, "    return &%s;\n", e->type->cxxTypeRefInfo->fieldName);
 	}
-	fprintf(src, "  return NULL;\n");
+	fprintf(src, "  return nullptr;\n");
 	fprintf(src, "}\n\n");
 
 #if TCL
@@ -6479,7 +6463,7 @@ void PrintCxxSetDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* set, Modu
 				fprintf(src, "    if (!present)\n");
 				fprintf(src, "    {\n");
 				fprintf(src, "      delete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "      %s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "      %s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 				fprintf(src, "    }\n");
 				fprintf(src, "  }\n");
 			}
@@ -6504,7 +6488,7 @@ void PrintCxxSetDefCodeMeta_1(FILE* hdr, FILE* src, TypeDef* td, Type* set, Modu
 			if (e->type->optional || e->type->defaultVal)
 			{
 				fprintf(src, "      delete %s;\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "      %s = NULL;\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "      %s = nullptr;\n", e->type->cxxTypeRefInfo->fieldName);
 			}
 			else
 			{

--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -419,6 +419,8 @@ void PrintClear(FILE* hdr, FILE* src, Module* m, TypeDef* td, Type* t)
 			}
 			fprintf(src, "\t\t\tbreak;\n");
 		}
+		fprintf(src, "\t\tdefault:\n");
+		fprintf(src, "\t\t\tbreak;\n");
 		fprintf(src, "\t}\n");
 		fprintf(src, "\tchoiceId = notinitialized;\n");
 	}
@@ -713,6 +715,8 @@ static void PrintAssignmentOperator(FILE* hdr, FILE* src, Module* m, Type* t, Ty
 				fprintf(src, "\t\t\t\t\t%s = that.%s;\n", e->type->cxxTypeRefInfo->fieldName, e->type->cxxTypeRefInfo->fieldName);
 			fprintf(src, "\t\t\t\t\tbreak;\n");
 		}
+		fprintf(src, "\t\t\t\tdefault:\n");
+		fprintf(src, "\t\t\t\t\tbreak;\n");
 		fprintf(src, "\t\t\t}\n");
 		fprintf(src, "\t\t}\n");
 	}
@@ -1845,7 +1849,7 @@ void PrintChoiceDefCodeBerEncodeContent(FILE* src, FILE* hdr, Module* m, CxxRule
 		/* encode tag (s) & len (s) */
 		PrintCxxTagAndLenEncodingCode(src, td, e->type, "l", "_b", "\t\t\t");
 
-		fprintf(src, "\t\tbreak;\n");
+		fprintf(src, "\t\t\tbreak;\n");
 	}
 	fprintf(src, "\t\tdefault:\n");
 	fprintf(src, "\t\t\tthrow EXCEPT(\"Choice is empty\", ENCODE_ERROR);\n");
@@ -2062,7 +2066,7 @@ void PrintChoiceDefCodeBerDecodeContent(FILE* src, FILE* hdr, Module* m, CxxRule
 				fprintf(src, "\t\t\t\tBDecEoc (_b, bytesDecoded);\n");
 			}
 
-			fprintf(src, "\t\tbreak;\n");
+			fprintf(src, "\t\t\tbreak;\n");
 			FreeTags(tags);
 		}
 	}
@@ -2075,13 +2079,13 @@ void PrintChoiceDefCodeBerDecodeContent(FILE* src, FILE* hdr, Module* m, CxxRule
 		fprintf(src, "\t\t\tchoiceId = extensionCid;\n");
 		fprintf(src, "\t\t\textAny.BDecContent(_b, tag, elmtLen0, bytesDecoded);\n");
 		fprintf(src, "\t\t\textension->extList.insert( extension->extList.end(), extAny );\n");
+		fprintf(src, "\t\t\tbreak;\n");
 	}
 	else
 	{
 		fprintf(src, "\t\t\tthrow InvalidTagException(typeName(), tag, STACK_ENTRY);\n");
 	}
 
-	fprintf(src, "\t\tbreak;\n");
 	fprintf(src, "\t}\n");
 	fprintf(src, "}\n\n");
 }
@@ -2583,26 +2587,28 @@ static void PrintCxxChoiceDefCode(FILE* src, FILE* hdr, ModuleList* mods, Module
 
 		FOR_EACH_LIST_ELMT(e, choice->basicType->a.choice)
 		{
-			fprintf(src, "\tcase %s:\n", e->type->cxxTypeRefInfo->choiceIdSymbol);
+			fprintf(src, "\t\tcase %s:\n", e->type->cxxTypeRefInfo->choiceIdSymbol);
 
 			/* value notation so print the choice elmts field name */
 			if (e->fieldName != NULL)
-				fprintf(src, "\t\tos << \"%s \";\n", e->fieldName);
+				fprintf(src, "\t\t\tos << \"%s \";\n", e->fieldName);
 
 			if (e->type->cxxTypeRefInfo->isPtr)
 			{
-				fprintf(src, "\t\tif (%s)\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "\t\t\t%s->Print(os, indent);\n", e->type->cxxTypeRefInfo->fieldName);
-				fprintf(src, "\t\telse\n");
-				fprintf(src, "\t\t\tos << \"<CHOICE value is missing>\\n\";\n");
+				fprintf(src, "\t\t\tif (%s)\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "\t\t\t\t%s->Print(os, indent);\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "\t\t\telse\n");
+				fprintf(src, "\t\t\t\tos << \"<CHOICE value is missing>\\n\";\n");
 			}
 			else
 			{
-				fprintf(src, "\t\t%s.Print(os, indent);\n", e->type->cxxTypeRefInfo->fieldName);
+				fprintf(src, "\t\t\t%s.Print(os, indent);\n", e->type->cxxTypeRefInfo->fieldName);
 			}
 
-			fprintf(src, "\t\tbreak;\n\n");
+			fprintf(src, "\t\t\tbreak;\n");
 		}
+		fprintf(src, "\t\tdefault:\n");
+		fprintf(src, "\t\t\tthrow EXCEPT(\"Choice is empty\", PARAMETER_ERROR);\n");
 		fprintf(src, "\t} // end of switch\n");
 
 		fprintf(src, "} // end of %s::Print()\n\n", td->cxxTypeDefInfo->className);
@@ -2640,20 +2646,19 @@ static void PrintCxxChoiceDefCode(FILE* src, FILE* hdr, ModuleList* mods, Module
 				else
 					fprintf(src, ");\n");
 				fprintf(src, "\t\t\telse\n");
-				fprintf(src, "\t\t\t{\n");
 
 				if (e->fieldName != NULL)
 					fprintf(src, "\t\t\t\tos << \"<%s -- void3 -- /%s>\" << std::endl;\n", e->fieldName, e->fieldName);
 				else
 					fprintf(src, "\t\t\t\tos << \"<%s -- void3 -- /%s>\" << std::endl;\n", e->type->cxxTypeRefInfo->fieldName, e->type->cxxTypeRefInfo->fieldName);
-
-				fprintf(src, "\t\t\t}\n");
 			}
 			else
 				fprintf(src, "\t\t\t%s.PrintXML(os, \"%s\");\n", e->type->cxxTypeRefInfo->fieldName, e->fieldName);
 
-			fprintf(src, "\t\tbreak;\n\n");
+			fprintf(src, "\t\t\tbreak;\n");
 		}
+		fprintf(src, "\t\tdefault:\n");
+		fprintf(src, "\t\t\tthrow EXCEPT(\"Choice is empty\", PARAMETER_ERROR);\n");
 		fprintf(src, "\t} // end of switch\n");
 		fprintf(src, "\tif (lpszTitle)\n");
 		fprintf(src, "\t\tos << \"</\" << lpszTitle << \">\";\n");
@@ -4004,7 +4009,7 @@ static void PrintCxxSetDefCode(FILE* src, FILE* hdr, ModuleList* mods, Module* m
 						mandatoryElmtCount++;
 						fprintf(src, "\t\t\tmandatoryElmtsDecoded++;\n");
 					}
-					fprintf(src, "\t\t\tbreak;\n\n");
+					fprintf(src, "\t\t\tbreak;\n");
 
 					FreeTags(tags);
 				}

--- a/compiler/back-ends/c++-gen/gen-code.h
+++ b/compiler/back-ends/c++-gen/gen-code.h
@@ -45,7 +45,7 @@ extern int gNO_NAMESPACE;
 extern const char* gAlternateNamespaceString;
 extern int genPERCode;
 // extern short ImportedFilesG;
-extern int genCodeCPPPrintStdAfxInclude; // Print stdafx.h includes
+extern int genCodeCPPPrintPCHInclude; // Print stdafx.h or pch.h includes
 
 static const char bufTypeNameG[] = "AsnBuf";
 static const char lenTypeNameG[] = "AsnLen";

--- a/compiler/back-ends/kotlin-gen/gen-kotlin-code.c
+++ b/compiler/back-ends/kotlin-gen/gen-kotlin-code.c
@@ -803,8 +803,8 @@ void PrintKotlinCode(ModuleList* allMods)
 	if (gMajorInterfaceVersion >= 0)
 	{
 		char szFileName[_MAX_PATH] = {0};
-		strcpy_s(szFileName, _MAX_PATH, gszOutputPath);
-		strcat_s(szFileName, _MAX_PATH, "Asn1InterfaceVersion");
+		strcpy_s(szFileName, _MAX_PATH - 1, gszOutputPath);
+		strcat_s(szFileName, _MAX_PATH - 1, "Asn1InterfaceVersion");
 		FILE* src = getKotlinFilePointer(szFileName);
 		if (src)
 		{

--- a/compiler/back-ends/ts-gen/gen-ts-code.c
+++ b/compiler/back-ends/ts-gen/gen-ts-code.c
@@ -474,11 +474,11 @@ void PrintTSSeqDefCode(FILE* src, ModuleList* mods, Module* m, TypeDef* td, Type
 			iMandatoryFields++;
 	}
 
-	// Jetzt schreiben wir den Konstruktor mit dem einen Argumenten was unserer eigenen Klasse entspricht
-	// Damit erzwingen wir die dedizierte Angabe der pflicht Attribute beim Konstruktor aufruf
+	// Now write the constructor with the single argument that matches our own class
+	// This enforces explicit specification of the required attributes when calling the constructor
 	fprintf(src, "\tpublic constructor(that");
 
-	// Haben wir keine Pflicht Elemente ist auch das Attribut am Konstruktor Optional
+	// If there are no required elements, the constructor argument is optional as well
 	if (!iMandatoryFields)
 		fprintf(src, "?");
 

--- a/compiler/back-ends/ts-gen/gen-ts-converter.c
+++ b/compiler/back-ends/ts-gen/gen-ts-converter.c
@@ -93,7 +93,7 @@ void Print_JSON_EncoderSetOfDefCode(FILE* src, ModuleList* mods, Module* m, Type
 	if (baseChoice == BASICTYPE_OCTETCONTAINING && pBase->a.stringContaining->basicType->choiceId == BASICTYPE_UTF8_STR)
 		baseChoice = BASICTYPE_UTF8_STR;
 
-	// Ist der Typ den wir iterieren eine basis Type?
+	// Is the type we are iterating over a base type?
 	if (IsSimpleType(baseChoice))
 	{
 		fprintf(src, "\t\tfor (const se of s) {\n");
@@ -139,7 +139,7 @@ void Print_BER_EncoderSetOfDefCode(FILE* src, ModuleList* mods, Module* m, TypeD
 	// Unser Sequence Typ
 	enum BasicTypeChoiceId choice = seqOf->basicType->a.sequenceOf->basicType->choiceId;
 
-	// Basis Typ der Sequence
+	// Base type of the sequence
 	BasicType* pRootBasicType = GetRootType(seqOf, NULL)->basicType;
 	enum BasicTypeChoiceId rootChoiceId = pRootBasicType->choiceId;
 	if (rootChoiceId == BASICTYPE_OCTETCONTAINING && pRootBasicType->a.stringContaining->basicType->choiceId == BASICTYPE_UTF8_STR)
@@ -151,7 +151,7 @@ void Print_BER_EncoderSetOfDefCode(FILE* src, ModuleList* mods, Module* m, TypeD
 	if (baseChoice == BASICTYPE_OCTETCONTAINING && pBase->a.stringContaining->basicType->choiceId == BASICTYPE_UTF8_STR)
 		baseChoice = BASICTYPE_UTF8_STR;
 
-	// Ist der Typ den wir iterieren eine basis Type?
+	// Is the type we are iterating over a base type?
 	if (IsSimpleType(baseChoice))
 	{
 		fprintf(src, "\t\tfor (const se of s) {\n");
@@ -1416,7 +1416,7 @@ void PrintTSEncoderDecoderCode(FILE* src, ModuleList* mods, Module* m, TypeDef* 
 	char* szConverted = FixName(td->definedName);
 
 	const char* szNameSpace = GetNameSpace(m);
-	// Simple Typen, also Typen die auf oberster Ebene nur einen anderen Namen bekomme haben
+	// Simple types, meaning types that only received a different name at the top level
 	// Bspw: AsnSystemTime ::= REAL
 	// brauchen keinen Encoder Decoder
 

--- a/compiler/back-ends/ts-gen/gen-ts-rose.c
+++ b/compiler/back-ends/ts-gen/gen-ts-rose.c
@@ -106,7 +106,7 @@ void SaveTSROSEFilesToOutputDirectory(const int genRoseStubs, const char* szPath
 	{
 		char szFileName[_MAX_PATH] = {0};
 		strcpy_s(szFileName, _MAX_PATH - 1, szPath);
-		strcat_s(szFileName, _MAX_PATH - 1, "TSInvokeContext.ts");
+		strcat_s(szFileName, _MAX_PATH - 1, "TSctx.ts");
 		SaveResourceToFile(ETS_INVOKE_CONTEXT, szFileName);
 	}
 }
@@ -118,8 +118,8 @@ void PrintTSROSEImports(FILE* src, ModuleList* mods, Module* mod)
 	fprintf(src, "// Global imports\n");
 	fprintf(src, "import { I%s, I%s_Handler } from \"./%s_Interface%s\";\n", mod->ROSEClassName, mod->ROSEClassName, mod->ROSEClassName, getCommonJSFileExtension());
 	fprintf(src, "import { ROSEError, ROSEInvoke, ROSEReject, ROSEResult } from \"./SNACCROSE%s\";\n", getCommonJSFileExtension());
-	fprintf(src, "import { AsnInvokeProblem, AsnInvokeProblemEnum, createInvokeReject, IASN1Transport, IASN1LogData, IReceiveInvokeContext, IInvokeHandler, ELogSeverity, ROSEBase } from \"./TSROSEBase%s\";\n", getCommonJSFileExtension());
-	fprintf(src, "import { ISendInvokeContextParams } from \"./TSInvokeContext%s\";\n", getCommonJSFileExtension());
+	fprintf(src, "import { AsnInvokeProblem, AsnInvokeProblemEnum, createInvokeReject, IASN1Transport, IASN1LogData, IReceivectx, IInvokeHandler, ELogSeverity, ROSEBase } from \"./TSROSEBase%s\";\n", getCommonJSFileExtension());
+	fprintf(src, "import { ISendctxParams } from \"./TSctx%s\";\n", getCommonJSFileExtension());
 
 	fprintf(src, "// Local imports\n");
 	fprintf(src, "import * as %s from \"./%s%s\";\n", GetNameSpace(mod), mod->moduleName, getCommonJSFileExtension());
@@ -182,7 +182,7 @@ void PrintTSROSEInterfaceEntry(FILE* src, ModuleList* mods, ValueDef* vd, bool b
 			Module* resultMod = GetImportModuleRefByClassName(pszResult, mods, m);
 			const char* resultNS = GetNameSpace(resultMod);
 			fprintf(src, bAsComment ? "public " : "\t");
-			fprintf(src, "invoke_%s(argument: %s.%s, invokeContext?: ISendInvokeContextParams): Promise<%s.%s", pszFunction, argumentNS, pszArgument, resultNS, pszResult);
+			fprintf(src, "invoke_%s(argument: %s.%s, ctx?: ISendctxParams): Promise<%s.%s", pszFunction, argumentNS, pszArgument, resultNS, pszResult);
 			if (pszError)
 			{
 				Module* errorMod = GetImportModuleRefByClassName(pszError, mods, m);
@@ -197,7 +197,7 @@ void PrintTSROSEInterfaceEntry(FILE* src, ModuleList* mods, ValueDef* vd, bool b
 		else if (!pszResult)
 		{
 			fprintf(src, bAsComment ? "public " : "\t");
-			fprintf(src, "event_%s(argument: %s.%s, invokeContext?: ISendInvokeContextParams): void", pszFunction, argumentNS, pszArgument);
+			fprintf(src, "event_%s(argument: %s.%s, ctx?: ISendctxParams): void", pszFunction, argumentNS, pszArgument);
 			fprintf(src, bAsComment ? " {\n}\n" : ";\n");
 		}
 	}
@@ -259,7 +259,7 @@ bool PrintTSROSEHandlerInterfaceEntry(FILE* src, ModuleList* mods, Module* m, Va
 				}
 				fprintf(src, "\n");
 			}
-			fprintf(src, " * @param invokeContext - Invokecontext from the asn.1 lib (containing invoke related data)\n");
+			fprintf(src, " * @param ctx - ctx from the asn.1 lib (containing invoke related data)\n");
 			if (pszResult)
 				fprintf(src, " * @returns - %s on success, %s on error or undefined if the function is not implemented\n", pszResult, pszError);
 			fprintf(src, " */\n");
@@ -273,7 +273,7 @@ bool PrintTSROSEHandlerInterfaceEntry(FILE* src, ModuleList* mods, Module* m, Va
 		const char* argumentNS = GetNameSpace(argumentMod);
 		Module* resultMod = GetImportModuleRefByClassName(pszResult, mods, m);
 		const char* resultNS = GetNameSpace(resultMod);
-		fprintf(src, "onInvoke_%s(argument: %s.%s, invokeContext: IReceiveInvokeContext): Promise<%s.%s", pszFunction, argumentNS, pszArgument, resultNS, pszResult);
+		fprintf(src, "onInvoke_%s(argument: %s.%s, ctx: IReceivectx): Promise<%s.%s", pszFunction, argumentNS, pszArgument, resultNS, pszResult);
 		if (pszError)
 		{
 			Module* errorMod = GetImportModuleRefByClassName(pszError, mods, m);
@@ -289,7 +289,7 @@ bool PrintTSROSEHandlerInterfaceEntry(FILE* src, ModuleList* mods, Module* m, Va
 		Module* argumentMod = GetImportModuleRefByClassName(pszArgument, mods, m);
 		const char* argumentNS = GetNameSpace(argumentMod);
 		fprintf(src, bAsComment ? "public " : "\t");
-		fprintf(src, "onEvent_%s(argument: %s.%s, invokeContext: IReceiveInvokeContext): void", pszFunction, argumentNS, pszArgument);
+		fprintf(src, "onEvent_%s(argument: %s.%s, ctx: IReceivectx): void", pszFunction, argumentNS, pszArgument);
 		fprintf(src, bAsComment ? " {\n}\n" : ";\n");
 	}
 	if (bAsComment)
@@ -302,8 +302,8 @@ void PrintTSROSEImport(FILE* src, ModuleList* mods, Module* mod)
 {
 	fprintf(src, "// [%s]\n", __FUNCTION__);
 
-	fprintf(src, "import { IReceiveInvokeContext, AsnInvokeProblem } from \"./TSROSEBase%s\";\n", getCommonJSFileExtension());
-	fprintf(src, "import { ISendInvokeContextParams } from \"./TSInvokeContext%s\";\n", getCommonJSFileExtension());
+	fprintf(src, "import { IReceivectx, AsnInvokeProblem } from \"./TSROSEBase%s\";\n", getCommonJSFileExtension());
+	fprintf(src, "import { ISendctxParams } from \"./TSctx%s\";\n", getCommonJSFileExtension());
 	fprintf(src, "// Local imports\n");
 	fprintf(src, "import * as %s from \"./%s%s\";\n", GetNameSpace(mod), mod->moduleName, getCommonJSFileExtension());
 
@@ -336,7 +336,7 @@ void PrintTSROSEHandlerInterface(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "// Contains all invokes of the interface (normally the server side)\n");
 	fprintf(src, "export interface I%s_Invoke_Handler {\n", m->ROSEClassName);
 	fprintf(src, "\t// Allows the implementer to (globally) implement an async local storage (thread local storage) for calls inside the called environment)\n");
-	fprintf(src, "\tsetLogContext?(argument: unknown, invokeContext: IReceiveInvokeContext): void;\n");
+	fprintf(src, "\tsetLogContext?(argument: unknown, ctx: IReceivectx): void;\n");
 	ValueDef* vd;
 	FOR_EACH_LIST_ELMT(vd, m->valueDefs)
 	{
@@ -352,7 +352,7 @@ void PrintTSROSEHandlerInterface(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "// Contains all events of the interface (normally the client side)\n");
 	fprintf(src, "export interface I%s_Event_Handler {\n", m->ROSEClassName);
 	fprintf(src, "\t// Allows the implementer to (globally) implement an async local storage (thread local storage) for calls inside the called environment)\n");
-	fprintf(src, "\tsetLogContext?(argument: unknown, invokeContext: IReceiveInvokeContext): void;\n");
+	fprintf(src, "\tsetLogContext?(argument: unknown, ctx: IReceivectx): void;\n");
 	FOR_EACH_LIST_ELMT(vd, m->valueDefs)
 	{
 		if (vd->value->type->basicType->choiceId == BASICTYPE_MACROTYPE)
@@ -373,7 +373,7 @@ void PrintTSROSEServerCopyPasteInterface(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "// [%s]\n", __FUNCTION__);
 
 	fprintf(src, "/* Copy paste code for the import statement\n");
-	fprintf(src, "import { IReceiveInvokeContext } from \"./TSROSEBase%s\";\n", getCommonJSFileExtension());
+	fprintf(src, "import { IReceivectx } from \"./TSROSEBase%s\";\n", getCommonJSFileExtension());
 	fprintf(src, "import * as ENetUC_Common from \"./ENetUC_Common%s\";\n", getCommonJSFileExtension());
 	fprintf(src, "import { %s } from \"./%s%s\";\n", GetNameSpace(m), RemovePath(m->baseFilePath), getCommonJSFileExtension());
 	fprintf(src, "*/\n");
@@ -381,13 +381,13 @@ void PrintTSROSEServerCopyPasteInterface(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "\n/**\n");
 	fprintf(src, " * Allows to set the log context for an invoke.\n");
 	fprintf(src, " * This method is called in advanced of methods handled inside this handler\n");
-	fprintf(src, " * The idea is to implement a async local storage based on the provided data from the argument or invokeContext\n");
+	fprintf(src, " * The idea is to implement a async local storage based on the provided data from the argument or ctx\n");
 	fprintf(src, " *\n");
 	fprintf(src, " * @param argument - the snacc rose argument\n");
-	fprintf(src, " * @param invokeContext - the invoke context\n");
+	fprintf(src, " * @param ctx - the invoke context\n");
 	fprintf(src, " */\n");
 	fprintf(src, "/*\n");
-	fprintf(src, "public setLogContext(argument: unknown, invokeContext: IReceiveInvokeContext): void {\n");
+	fprintf(src, "public setLogContext(argument: unknown, ctx: IReceivectx): void {\n");
 	fprintf(src, "}\n");
 	fprintf(src, "*/\n\n");
 
@@ -536,7 +536,7 @@ void PrintTSROSEOnInvokeswitchCaseEntry(FILE* src, ModuleList* mods, int bEvents
 			{
 				asnoperationcomment comment;
 				GetOperationComment_UTF8(m->moduleName, vd->definedName, &comment);
-				fprintf(src, "\t\t\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"IN\", invokeContext);\n", comment.i64Deprecated, pszFunction);
+				fprintf(src, "\t\t\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"IN\", ctx);\n", comment.i64Deprecated, pszFunction);
 			}
 			fprintf(src, "\t\t\t\treturn await this.handleOnInvoke(invoke, ");
 			fprintf(src, "OperationIDs.OPID_%s, ", pszFunction);
@@ -551,7 +551,7 @@ void PrintTSROSEOnInvokeswitchCaseEntry(FILE* src, ModuleList* mods, int bEvents
 				fprintf(src, "%s_Converter.%s_Converter, ", szResultNS, pszResult);
 			fprintf(src, "handler, ");
 			fprintf(src, "handler.onInvoke_%s, ", pszFunction);
-			fprintf(src, "invokeContext);\n");
+			fprintf(src, "ctx);\n");
 		}
 		else if (!pszResult && bEvents)
 		{
@@ -560,7 +560,7 @@ void PrintTSROSEOnInvokeswitchCaseEntry(FILE* src, ModuleList* mods, int bEvents
 			{
 				asnoperationcomment comment;
 				GetOperationComment_UTF8(m->moduleName, vd->definedName, &comment);
-				fprintf(src, "\t\t\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"IN\", invokeContext);\n", comment.i64Deprecated, pszFunction);
+				fprintf(src, "\t\t\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"IN\", ctx);\n", comment.i64Deprecated, pszFunction);
 			}
 			fprintf(src, "\t\t\t\treturn await this.handleOnEvent(invoke, ");
 			fprintf(src, "OperationIDs.OPID_%s, ", pszFunction);
@@ -571,7 +571,7 @@ void PrintTSROSEOnInvokeswitchCaseEntry(FILE* src, ModuleList* mods, int bEvents
 				fprintf(src, "%s_Converter.%s_Converter, ", szArgumentNS, pszArgument);
 			fprintf(src, "handler, ");
 			fprintf(src, "handler.onEvent_%s, ", pszFunction);
-			fprintf(src, "invokeContext);\n");
+			fprintf(src, "ctx);\n");
 		}
 	}
 }
@@ -587,12 +587,12 @@ void PrintTSROSEOnInvokeswitchCase(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "\t * @param invoke - The (ROSE) decoded invoke which also contains the function argument (not yet decoded). The\n");
 	fprintf(src, "\t * operationID is the one that defines which function we call. In the switch case we decode the methods argument\n");
 	fprintf(src, "\t * and call the metho in the handler.\n");
-	fprintf(src, "\t * @param invokeContext - The invoke related contextual data (see IReceiveInvokeContext)\n");
+	fprintf(src, "\t * @param ctx - The invoke related contextual data (see IReceivectx)\n");
 	fprintf(src, "\t * @param handler - This object is handling the invoke after having successfully decoded the argument.\n");
 	fprintf(src, "\t * it contains the methods as defined in the asn.1 files.\n");
 	fprintf(src, "\t * @returns ROSEReject if the request was not handled, ROSEResult for the invoke result, ROSEError for an error or undefined if an event was called\n");
 	fprintf(src, "\t */\n");
-	fprintf(src, "\tpublic async onInvoke(invoke: ROSEInvoke, invokeContext: IReceiveInvokeContext, handler: I%s_Handler): Promise<ROSEReject | ROSEResult | ROSEError | undefined> {\n", m->ROSEClassName);
+	fprintf(src, "\tpublic async onInvoke(invoke: ROSEInvoke, ctx: IReceivectx, handler: I%s_Handler): Promise<ROSEReject | ROSEResult | ROSEError | undefined> {\n", m->ROSEClassName);
 	fprintf(src, "\t\tswitch (invoke.operationID) {\n");
 
 	ValueDef* vd;
@@ -625,7 +625,7 @@ void PrintTSROSEOnInvokeswitchCase(FILE* src, ModuleList* mods, Module* m)
 		}
 	}
 	if (addedOne)
-		fprintf(src, "\t\t\t\treturn this.onEvent(invoke, invokeContext, handler);\n");
+		fprintf(src, "\t\t\t\treturn this.onEvent(invoke, ctx, handler);\n");
 
 	fprintf(src, "\t\t\tdefault:\n");
 	fprintf(src, "\t\t\t\t// If you land here stub of client and server are incompatible...\n");
@@ -646,16 +646,16 @@ void PrintTSROSEOnEventSwitchCase(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "\t * @param invoke - The (ROSE) decoded invoke which also contains the function argument (not yet decoded). The\n");
 	fprintf(src, "\t * operationID is the one that defines which function we call. In the switch case we decode the methods argument\n");
 	fprintf(src, "\t * and call the method in the handler.\n");
-	fprintf(src, "\t * @param invokeContext - The invoke related contextual data (see IReceiveInvokeContext)\n");
+	fprintf(src, "\t * @param ctx - The invoke related contextual data (see IReceivectx)\n");
 	fprintf(src, "\t * @param handler - This object is handling the invoke after having successfully decoded the argument.\n");
 	fprintf(src, "\t * it contains the methods as defined in the asn.1 files.\n");
 	fprintf(src, "\t * @returns ROSEReject if the request was not handled or undefined\n");
 	fprintf(src, "\t */\n");
-	fprintf(src, "\tprivate async onEvent(invoke: ROSEInvoke, invokeContext: IReceiveInvokeContext, handler: I%s_Handler): Promise<ROSEReject | undefined> {\n", m->ROSEClassName);
-	fprintf(src, "\t\t// If the class says do not handle events and the override flag in the invokeContext has not been set, add the event to the que, otherwise we dispatch it\n");
-	fprintf(src, "\t\tif (!this.handleEvents && !invokeContext?.handleEvent) {\n");
+	fprintf(src, "\tprivate async onEvent(invoke: ROSEInvoke, ctx: IReceivectx, handler: I%s_Handler): Promise<ROSEReject | undefined> {\n", m->ROSEClassName);
+	fprintf(src, "\t\t// If the class says do not handle events and the override flag in the ctx has not been set, add the event to the que, otherwise we dispatch it\n");
+	fprintf(src, "\t\tif (!this.handleEvents && !ctx?.handleEvent) {\n");
 	fprintf(src, "\t\t\tthis.transport.log(ELogSeverity.debug, \"Adding event to queue\", \"onEvent\", this, { operationName: invoke.operationName, operationID: invoke.operationID });\n");
-	fprintf(src, "\t\t\tthis.cachedEvents.push({ invoke, invokeContext, handler });\n");
+	fprintf(src, "\t\t\tthis.cachedEvents.push({ invoke, ctx, handler });\n");
 	fprintf(src, "\t\t\treturn;\n");
 	fprintf(src, "\t\t}\n\n");
 
@@ -740,7 +740,7 @@ bool PrintTSROSEInvokeMethod(FILE* src, ModuleList* mods, int bEvents, ValueDef*
 					}
 
 					fprintf(src, "\t * @param argument - An %s object containing all the relevant parameters for the call\n", pszArgument);
-					fprintf(src, "\t * @param invokeContext - Invoke related contextual data (e.g. a clientConnectionID)\n");
+					fprintf(src, "\t * @param ctx - Invoke related contextual data (e.g. a clientConnectionID)\n");
 					if (pszResult && !bEvents)
 						fprintf(src, "\t * @returns a Promise resolving into %s, an AsnRequestError or AsnInvokeProblem object\n", pszResult);
 					else if (bEvents)
@@ -751,7 +751,7 @@ bool PrintTSROSEInvokeMethod(FILE* src, ModuleList* mods, int bEvents, ValueDef*
 
 			if (pszResult && !bEvents)
 			{
-				fprintf(src, "\tpublic async invoke_%s(argument: %s.%s, invokeContext?: ISendInvokeContextParams): Promise<%s.%s", pszFunction, szArgumentNS, pszArgument, szResultNS, pszResult);
+				fprintf(src, "\tpublic async invoke_%s(argument: %s.%s, ctx?: ISendctxParams): Promise<%s.%s", pszFunction, szArgumentNS, pszArgument, szResultNS, pszResult);
 				const char* szErrorNS = GetNameSpace(errorMod);
 				if (szErrorNS && pszError)
 					fprintf(src, " | %s.%s", szErrorNS, pszError);
@@ -760,7 +760,7 @@ bool PrintTSROSEInvokeMethod(FILE* src, ModuleList* mods, int bEvents, ValueDef*
 				{
 					asnoperationcomment comment;
 					GetOperationComment_UTF8(m->moduleName, vd->definedName, &comment);
-					fprintf(src, "\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"OUT\", invokeContext);\n", comment.i64Deprecated, pszFunction);
+					fprintf(src, "\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"OUT\", ctx);\n", comment.i64Deprecated, pszFunction);
 				}
 				fprintf(src, "\t\treturn this.handleInvoke(argument, ");
 				fprintf(src, "%s.%s, ", szResultNS, pszResult);
@@ -774,7 +774,7 @@ bool PrintTSROSEInvokeMethod(FILE* src, ModuleList* mods, int bEvents, ValueDef*
 					fprintf(src, "Converter.%s_Converter, ", pszResult);
 				else
 					fprintf(src, "%s_Converter.%s_Converter, ", szResultNS, pszResult);
-				fprintf(src, "invokeContext");
+				fprintf(src, "ctx");
 
 				if (pszError && strcmp(pszError, "AsnRequestError") != 0)
 				{
@@ -790,12 +790,12 @@ bool PrintTSROSEInvokeMethod(FILE* src, ModuleList* mods, int bEvents, ValueDef*
 			}
 			else if (!pszResult && bEvents)
 			{
-				fprintf(src, "\tpublic event_%s(argument: %s.%s, invokeContext?: ISendInvokeContextParams): undefined | boolean {\n", pszFunction, szArgumentNS, pszArgument);
+				fprintf(src, "\tpublic event_%s(argument: %s.%s, ctx?: ISendctxParams): undefined | boolean {\n", pszFunction, szArgumentNS, pszArgument);
 				if (bDeprecated)
 				{
 					asnoperationcomment comment;
 					GetOperationComment_UTF8(m->moduleName, vd->definedName, &comment);
-					fprintf(src, "\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"OUT\", invokeContext);\n", comment.i64Deprecated, pszFunction);
+					fprintf(src, "\t\tTSDeprecatedCallback.deprecatedMethod(%lld, this.getLogData().className, \"%s\", \"OUT\", ctx);\n", comment.i64Deprecated, pszFunction);
 				}
 				fprintf(src, "\t\treturn this.handleEvent(argument, ");
 				fprintf(src, "OperationIDs.OPID_%s, ", pszFunction);
@@ -804,7 +804,7 @@ bool PrintTSROSEInvokeMethod(FILE* src, ModuleList* mods, int bEvents, ValueDef*
 					fprintf(src, "Converter.%s_Converter, ", pszArgument);
 				else
 					fprintf(src, "%s_Converter.%s_Converter, ", szArgumentNS, pszArgument);
-				fprintf(src, "invokeContext);\n");
+				fprintf(src, "ctx);\n");
 				fprintf(src, "\t}\n");
 			}
 			return true;

--- a/compiler/core/efileressources.c
+++ b/compiler/core/efileressources.c
@@ -20,7 +20,7 @@ INCBIN(BIN_ASN1_SERVER, "compiler/back-ends/ts-gen/gluecode/TSASN1Server.ts");
 INCBIN(BIN_ROSE_BASE, "compiler/back-ends/ts-gen/gluecode/TSROSEBase.ts");
 INCBIN(BIN_SNACCROSE, "compiler/back-ends/ts-gen/gluecode/SNACCROSE.ts");
 INCBIN(BIN_SNACCROSE_CONVERTER, "compiler/back-ends/ts-gen/gluecode/SNACCROSE_Converter.ts");
-INCBIN(BIN_INVOKE_CONTEXT, "compiler/back-ends/ts-gen/gluecode/TSctx.ts");
+INCBIN(BIN_INVOKE_CONTEXT, "compiler/back-ends/ts-gen/gluecode/TSInvokeContext.ts");
 INCBIN(BIN_DEPRECATED_CALLBACK, "compiler/back-ends/ts-gen/gluecode/TSDeprecatedCallback.ts");
 
 INCBIN(BIN_EDELPHI_ASN1_YPES, "compiler/back-ends/delphi-gen/gluecode/DelphiAsn1Types.pas");

--- a/compiler/core/efileressources.c
+++ b/compiler/core/efileressources.c
@@ -20,7 +20,7 @@ INCBIN(BIN_ASN1_SERVER, "compiler/back-ends/ts-gen/gluecode/TSASN1Server.ts");
 INCBIN(BIN_ROSE_BASE, "compiler/back-ends/ts-gen/gluecode/TSROSEBase.ts");
 INCBIN(BIN_SNACCROSE, "compiler/back-ends/ts-gen/gluecode/SNACCROSE.ts");
 INCBIN(BIN_SNACCROSE_CONVERTER, "compiler/back-ends/ts-gen/gluecode/SNACCROSE_Converter.ts");
-INCBIN(BIN_INVOKE_CONTEXT, "compiler/back-ends/ts-gen/gluecode/TSInvokeContext.ts");
+INCBIN(BIN_INVOKE_CONTEXT, "compiler/back-ends/ts-gen/gluecode/TSctx.ts");
 INCBIN(BIN_DEPRECATED_CALLBACK, "compiler/back-ends/ts-gen/gluecode/TSDeprecatedCallback.ts");
 
 INCBIN(BIN_EDELPHI_ASN1_YPES, "compiler/back-ends/delphi-gen/gluecode/DelphiAsn1Types.pas");

--- a/compiler/core/snacc.c
+++ b/compiler/core/snacc.c
@@ -503,7 +503,7 @@ int main PARAMS((argc, argv), int argc _AND_ char** argv)
 					if (strcmp(argument + 1, "stdafx") == 0)
 					{
 						/* ste --added */
-						genCodeCPPPrintStdAfxInclude = 1;
+						genCodeCPPPrintPCHInclude = 1;
 						currArg++;
 					}
 					break;
@@ -563,7 +563,10 @@ int main PARAMS((argc, argv), int argc _AND_ char** argv)
 					currArg++;
 					break;
 				case 'p':
-					genPrintCode = TRUE;
+					if (strcmp(argument + 1, "pch") == 0)
+						genCodeCPPPrintPCHInclude = 2;
+					else
+						genPrintCode = TRUE;
 					currArg++;
 					break;
 				case 'x':

--- a/cpp-lib/include/SNACCDeprecated.h
+++ b/cpp-lib/include/SNACCDeprecated.h
@@ -42,9 +42,9 @@ public:
 	 * @param szMethodName - the name of the method that has been called
 	 * @param direction - whether the call was inbound or outbound
 	 * @param callStack - the call stack that shows where the object has been created
-	 * @param pContext - The invoke Context that is associated with the invoke
+	 * @param ctx - the invoke context that is associated with the invoke
 	 */
-	virtual void DeprecatedASN1Method(const long long i64DeprecatedSince, const char* szModuleName, const char* szMethodName, const SNACCDeprecatedNotifyCallDirection direction, const std::list<std::string>& callStack, const SnaccInvokeContext* pContext = NULL) = 0;
+	virtual void DeprecatedASN1Method(const long long i64DeprecatedSince, const char* szModuleName, const char* szMethodName, const SNACCDeprecatedNotifyCallDirection direction, const std::list<std::string>& callStack, const SnaccInvokeContext& ctx) = 0;
 };
 
 class SNACCDeprecated
@@ -74,9 +74,9 @@ public:
 	 * @param szModuleName - the module in which the object is located
 	 * @param szMethodName - the name of the method that has been called
 	 * @param direction - whether the call was inbound or outbound
-	 * @param pContext - the invokeContext that shows more details about the invoke
+	 * @param ctx - the invoke context that shows more details about the invoke
 	 */
-	static void DeprecatedASN1Method(const long long i64DeprecatedSince, const char* szModuleName, const char* szMethodName, const SNACCDeprecatedNotifyCallDirection direction, const SnaccInvokeContext* pContext = NULL);
+	static void DeprecatedASN1Method(const long long i64DeprecatedSince, const char* szModuleName, const char* szMethodName, const SNACCDeprecatedNotifyCallDirection direction, SnaccInvokeContext& ctx);
 
 private:
 	/**

--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -4,12 +4,14 @@
 /*! Requires std::map */
 #include <set>
 #include <map>
+#include <memory>
 #include <functional>
 #include <string>
 #include <mutex>
 #include <wchar.h>
 #include <optional>
 #include "SnaccROSEInterfaces.h"
+#include "SnaccTelemetry.h"
 #include "syncevent.h"
 
 #if defined(_MSC_VER)
@@ -41,12 +43,19 @@ class SnaccROSEPendingOperation
 {
 private:
 	SyncEvent m_CompletedEvent;
+	SnaccROSEPendingOperation(long lInvokeID, unsigned int uiOperationID, const char* szOperationName);
 
 public:
-	SnaccROSEPendingOperation();
+	static std::unique_ptr<SnaccROSEPendingOperation> Create(long lInvokeID, unsigned int uiOperationID, const char* szOperationName)
+	{
+		return std::unique_ptr<SnaccROSEPendingOperation>(new SnaccROSEPendingOperation(lInvokeID, uiOperationID, szOperationName));
+	}
+
 	~SnaccROSEPendingOperation();
 
-	long m_lInvokeID;
+	const long m_lInvokeID;
+	const unsigned int m_uiOperationID{};
+	const std::string m_strOperationName;
 
 	/*! The answer message. */
 	const SNACC::ROSEMessage* m_pAnswerMessage;
@@ -54,18 +63,24 @@ public:
 	/*! Error code (one of the ROSE_ error codes. */
 	long m_lRoseResult;
 
+	/*! Encoded size of the received response payload. */
+	size_t m_stResponseData{};
+
+	/*! Outbound invoke telemetry tracked alongside the pending completion state. */
+	std::shared_ptr<SnaccTelemetryData> m_pTelemetry;
+
 	/*! Async Operation completed.
 		Attention: The AnswerMessage will not be copied.
 		The AnswerMessage must be new allocated and will be deleted
 		when processed. */
-	void CompleteOperation(long lRoseResult, const SNACC::ROSEMessage* pAnswerMessage);
+	void CompleteOperation(long lRoseResult, const SNACC::ROSEMessage* pAnswerMessage, size_t stResponseData = 0);
+	void FinalizeTelemetry(std::shared_ptr<SnaccInvokeContext> pctx);
 
 	/*! Wait for answer received. */
 	bool WaitForComplete(long lTimeOut = -1);
 };
 
-typedef std::map<long, SnaccROSEPendingOperation*> SnaccROSEPendingOperationMap;
-typedef std::pair<long, SnaccROSEPendingOperation*> SnaccROSEPendingOperationPair;
+typedef std::map<long, std::unique_ptr<SnaccROSEPendingOperation>> SnaccROSEPendingOperationMap;
 
 class SnaccROSEBase;
 
@@ -87,40 +102,6 @@ private:
 	static inline std::map<std::string, unsigned int> m_mapOpToID;
 	static inline std::map<unsigned int, std::string> m_mapIDToOp;
 	static inline std::map<unsigned int, unsigned int> m_mapIDToInterface;
-};
-
-// Invoke Context
-// This context is passed to all OnInvoke_ functions
-// This context can be transferred to the Invoke_ functions
-// The ROSEAuth members are automatically deleted, created with new
-class SnaccInvokeContext
-{
-public:
-	SnaccInvokeContext();
-	virtual ~SnaccInvokeContext();
-
-	// Meaning in OnInvoke_: Authentication Header from the ROSE Invoke (Pointer to the object in the invoke)
-	// Meaning in Invoke_: Authentication Header that is dispatched along with the invoke (create it with new, cleanup is done inside)
-	SNACC::ROSEAuthRequest* pInvokeAuth;
-
-	// Meaning in OnInvoke_: Authentication Header, which is returned in the reject if the method returnReject returns must be created with new, is cleaned up itself
-	// Meaning in Invoke_: If the method returnsReject, this member contains the optional reject authentication (only if SNACC_REJECT_AUTH_INCOMPLETE)
-	SNACC::ROSEAuthResult* pRejectAuth;
-
-	// Reject Result Code: 0 or ROSE_REJECT_AUTHENTICATIONFAILED or ROSE_REJECT_AUTHENTICATIONINCOMPLETE
-	// Meaning in Invoke_: If the method returns returnReject, this member contains ROSE_REJECT_AUTHENTICATIONINCOMPLETE or ROSE_REJECT_AUTHENTICATIONFAILED if the authentication was not successful
-	// Special: ROSE_REJECT_ASYNCOPERATION - no result is sent.
-	long lRejectResult;
-
-	// Meaning in OnInvoke_: Function that is called after the result has been returned.
-	// Usage: cxt->funcAfterResult = [this, strCrossRefID]() -> void { /* executed after result has been sent. */ };
-	std::function<void()> funcAfterResult;
-
-	// Meaning in OnInvoke_: Originaler Invoke
-	SNACC::ROSEInvoke* pInvoke;
-
-	// A Custom void pointer that allows the caller to add custom data to the transport layer that is dispatching a request
-	void* pCustom;
 };
 
 #define SNACC_TE_BER SNACC::TransportEncoding::BER
@@ -150,12 +131,19 @@ public:
 	The generated class overrides OnInvoke to implement the OnInvoke_XXX handlers.
 	The generated class calls the Invoke function from the Invoke_XXX functions.
 	*/
-class SnaccROSEBase : public SnaccROSESender
+class SnaccROSEBase : public SnaccROSESender, public SnaccTelemetryCallback
 {
 public:
-	SnaccROSEBase(void);
-	SnaccROSEBase(const std::set<int>& multithreadInvokeIDs);
+	SnaccROSEBase(const wchar_t* szClassName);
+	SnaccROSEBase(const wchar_t* szClassName, const std::set<int>& multithreadInvokeIDs);
 	virtual ~SnaccROSEBase(void);
+
+	/*
+	 * Allows to set a central callback for telemetry data the SnaccROSEBase class is providing
+	 * The implementer can either overwrite OnInvokeProcessed in this class or set
+	 * the central callback to gather telemetry data for inbound and outbound messages.
+	 */
+	static void SetTelemetryCallback(SnaccTelemetryCallback* pCallBack);
 
 	/*! Set timeout for function invokes.
 		Wait time in milliseconds */
@@ -184,7 +172,7 @@ public:
 	/* Output of the binary data.
 		Override this function to send the data to the transport layer.
 		Optional you can set a ISnaccROSETransport Interface to receive the outbound data*/
-	virtual long SendBinaryDataBlockEx(const char* lpBytes, unsigned long lSize, SnaccInvokeContext* pCtx);
+	virtual long SendBinaryDataBlockEx(const char* lpBytes, size_t Size, SnaccInvokeContext& ctx);
 
 	/*! Set a ISnaccROSETransport Interface to be called when outbound Data must be sent.
 		This is an alternative to overriding SendBinaryDataBlock */
@@ -213,31 +201,48 @@ public:
 		length = length of the szData (as it is not necessarily null terminated respect the length!)
 		returns true if data was logged
 	*/
-	virtual bool PrintJSONToLog(const bool bOutbound, const bool bError, const char* szOperationName, const char* szData, const size_t length = 0);
+	virtual bool PrintJSONToLog(const bool bOutbound, const bool bError, const char* szOperationName, const char* szData, const size_t size = 0);
 
 	/* Set the Transport Encoding to be used */
 	bool SetTransportEncoding(const SNACC::TransportEncoding transportEncoding);
 	SNACC::TransportEncoding GetTransportEncoding() const;
 
-	/* Send a Result Message. */
-	virtual long SendResult(SNACC::ROSEResult* presult);
-
-	/* Send a Result Message.
-		Override from SnaccRoseSender */
-	virtual long SendResult(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, const wchar_t* szSessionID = 0) override;
+	/*
+	 * Encodes a result as repsonse to an invoke
+	 *
+	 * uiInvokeID - the inbound invoke that we send the error for
+	 * pResult - the actual result object
+	 * strResponse - the encoded response data to send via the transport layer
+	 * szSessionID - the SessionID (this propery is filled by subclassing from the concrete class in case we are handling multiple clients via one connection)
+	 */
+	virtual long EncodeResult(unsigned int uiInvokeID, SNACC::AsnType* pResult, std::string& strResponse, const wchar_t* szSessionID = nullptr) override;
 
 	/* Send a Reject Message. */
-	long SendReject(SNACC::ROSEReject* preject);
-	/* Send back reject message.
-		Invoke Problem */
-	long SendRejectInvoke(int invokeID, SNACC::InvokeProblem problem, const char* szError = NULL, const wchar_t* szSessionID = 0, SNACC::ROSEAuthResult* pAuthHeader = 0);
+	long EncodeReject(SNACC::ROSEReject* preject, std::string& strResponse);
+	long SendRejectEx(SNACC::ROSEReject* preject);
 
-	/* Send a Error Message */
-	long EncodeError(const SNACC::ROSEError* perror, std::string& strResponse);
+	/*
+	 * Encodes a reject as repsonse to an invoke
+	 *
+	 * uiInvokeID - the inbound invoke that we send the error for
+	 * problem - the reject cause
+	 * strResponse - the encoded response data to send via the transport layer
+	 * szError - an optional error description (basically the problem as text, used for json encoded results)
+	 * szSessionID - the SessionID as taken from the invoke
+	 * pAuthHeader - an optional Auth header
+	 */
+	long EncodeRejectInvoke(unsigned int uiInvokeID, SNACC::InvokeProblem problem, std::string& strResponse, const char* szError = nullptr, const wchar_t* szSessionID = nullptr, SNACC::ROSEAuthResult* pAuthHeader = nullptr);
+	long EncodeInvokeRejectResponse(const SNACC::ROSEInvoke* pInvoke, long lProtocolResult, SnaccInvokeContext& ctx, std::string& strResponse);
 
-	/* Send a Error Message.
-		Override from SnaccRoseSender */
-	virtual long EncodeError(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pError, const wchar_t* szSessionID, std::string& strResponse) override;
+	/*
+	 * Encodes an error as repsonse to an invoke
+	 *
+	 * uiInvokeID - the inbound invoke that we send the error for
+	 * pError - the actual error object
+	 * strResponse - the encoded response data to send via the transport layer
+	 * szSessionID - the SessionID (this propery is filled by subclassing from the concrete class in case we are handling multiple clients via one connection)
+	 */
+	virtual long EncodeError(unsigned int uiInvokeID, SNACC::AsnType* pError, std::string& strResponse, const wchar_t* szSessionID = nullptr) override;
 
 	/*! Increment invoke counter
 		Override from SnaccRoseSender*/
@@ -261,51 +266,52 @@ public:
 	 * An invoke that is send to the other side. Should only be called by the ROSE stub itself generated files
 	 *
 	 * pInvoke - the invoke payload (it is put into a ROSEMessage in the function)
-	 * pResponse - the response payload (is handled afterwards in the HandleInvokeResult method
+	 * result - decoded result payload in case a result response is received
+	 * error - decoded error payload in case an error response is received
 	 * szOperationName - the operationName (for logging purposes)
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don�t care about the result))
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don�t care about the result))
-	 * pCtx - contextual data for the invoke
+	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don't care about the result))
+	 * pCtx - contextual data for the invoke. The caller may keep another shared reference
+	 *        to inspect changes after the call.
 	 */
-	virtual long SendInvoke(SNACC::ROSEInvoke* pinvoke, const SNACC::ROSEMessage** pResponse, const char* szOperationName, int iTimeout = -1, SnaccInvokeContext* pCtx = nullptr) override;
+	virtual long SendInvoke(SNACC::ROSEInvoke* pinvoke, SNACC::AsnType* result, SNACC::AsnType* error, const char* szOperationName, int iTimeout = -1, std::shared_ptr<SnaccInvokeContext> pCtx = {}) override;
 
 	/**
-	 * Handles the response payload of the SendInvoke method. Retrieves the result or error from the response
-	 *
-	 * lRoseResult - the result of the SendInvoke method
-	 * pResponseMsg - the response message as provided by the SendInvoke method
-	 * result - the result object (Base type pointer, the caller of the invoke provides the proper type)
-	 * error - the error object (Base type pointer, the caller of the invoke provides the proper type)
-	 * pCtx - contextual data for the invoke
-	 */
-	virtual long HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage* pResponseMsg, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext* cxt) override;
-
-	/** Encodes the result or error from an OnInvoke request. Retrieves the result or error from the response
+	 * Encodes the result or error from an OnInvoke request. Retrieves the result or error from the response
 	 *
 	 * invokeResult - the result of the OnInvoke method
+	 * pInvoke - the original invoke
+	 * ctx - contextual data for the invoke
 	 * strResponse - the encoded result to put it on the transport
-	 * result - the result object (Base type pointer, the caller of the invoke provides the proper type)
-	 * error - the error object (Base type pointer, the caller of the invoke provides the proper type)
-	 * pCtx - contextual data for the invoke
+	 * pResult - the result object (Base type pointer, the caller of the invoke provides the proper type)
+	 * pError - the error object (Base type pointer, the caller of the invoke provides the proper type)
 	 */
-	virtual long HandleOnInvokeResult(SNACC::InvokeResult invokeResult, std::string& strResponse, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext* cxt) override;
-
-	/** An event (invoke without result) that is send to the other side. Should only be called by the ROSE stub itself generated files
-	 *
-	 * pInvoke - the invoke payload (it is put into a ROSEMessage in the function)
-	 * pCtx - contextual data for the invoke
-	 */
-	virtual long SendEvent(SNACC::ROSEInvoke* pinvoke, const char* szOperationName, SnaccInvokeContext* cxt = nullptr) override;
+	virtual long HandleOnInvokeResult(SNACC::InvokeResult invokeResult, const SNACC::ROSEInvoke* pInvoke, SnaccInvokeContext& ctx, std::string& strResponse, SNACC::AsnType* pResult, SNACC::AsnType* pError) override;
 
 	/**
-	 * Helper method that retrieves the proper object (result, error, reject) from the repsonse Message
+	 * Allows implementers to customize the decoded invoke response before it is handed back
+	 * to the caller, for example to propagate connection-specific session data.
 	 *
-	 * pResponseMsg - the response message as provided by the SendInvoke method
-	 * ppResult - filled with the result object in case we have received a result
-	 * ppError - filled with the error object in case we have received an error
-	 * pCtx - contextual data from the invoke
+	 * lRoseResult - the current ROSE result code
+	 * pResponseMsg - the raw response message that was received
+	 * result - the decoded result payload in case a result response is received
+	 * error - the decoded error payload in case an error response is received
+	 * ctx - contextual data for the invoke
 	 */
-	static long DecodeResponse(const SNACC::ROSEMessage* pResponse, SNACC::ROSEResult** ppResult, SNACC::ROSEError** ppError, SnaccInvokeContext* pCtx);
+	virtual long HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage* pResponseMsg, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext& ctx) override;
+
+	/**
+	 * An event (invoke without result) that is send to the other side. Should only be called by the ROSE stub itself generated files
+	 *
+	 * pinvoke - the invoke payload (it is put into a ROSEMessage in the function)
+	 * pCtx - contextual data for the invoke. The caller may keep another shared reference
+	 *        to inspect changes after the call.
+	 */
+	virtual long SendEvent(SNACC::ROSEInvoke* pinvoke, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx = {}) override;
+
+	/**
+	 * Creates the invoke context for inbound and outbound invoke lifecycles.
+	 */
+	std::shared_ptr<SnaccInvokeContext> CreateInvokeContext(const SnaccInvokeContextInit& init) override;
 
 	/**
 	 * Decodes an invoke and properly handles logging for it
@@ -320,10 +326,10 @@ protected:
 	// In case the message is longer than 9999999 which is the longest possible length returns ROSE_TE_ENCODE_FAILED
 	long GetJsonLengthPrefix(std::string_view strJson, std::string& strLenghtPrefix) const;
 
-	/*! Die functions and events.
+	/*! The functions and events.
 		The implementation of this functions is contained in the generated code from the
 		esnacc. */
-	virtual long OnInvoke(const SNACC::ROSEMessage* pMsg, SnaccInvokeContext* cxt) = 0;
+	virtual long OnInvoke(SNACC::ROSEMessage* pMsg, SnaccInvokeContext& ctx, std::string& strResponse) = 0;
 
 	/* Function is called when a received data Packet cannot be decoded (invalid Rose Message)
 	 * bAlreadyTransportLogged	- true if the transport data has already been logged in the tranport log (so we do not need to log it again)
@@ -340,87 +346,55 @@ protected:
 		pmessage is new allocated and must be deleted inside this function.
 		returns true if the message was processed.
 		set bAllowInvokes to false, if invokes are not processed. */
-	virtual bool OnROSEMessage(const SNACC::ROSEMessage* pmessage, bool bAllowInvokes, unsigned long ulMessageSize);
+	virtual bool OnROSEMessage(SNACC::ROSEMessage* pmessage, bool bAllowInvokes, unsigned long ulMessageSize);
 
 	/*
-	 * This callback allows the implementer to enrich the invokecontext with data in case it wants to add or tune it
-	 *
-	 * @param pInvokeContext - the context that has just been created (some properties are already filled such as the pInvoke and the pInvokeAuth)
-	 * @return true in case you implement the fuction (the stub will then call)
+	 * This callback provides telemetry data for processed ROSE messages.
 	 */
-	virtual bool OnInvokeContextCreated(SnaccInvokeContext* pInvokeContext)
-	{
-		return false;
-	};
-
-	/*
-	 * This callback is called before the invokeContext runs out of scope.
-	 * It's only called if the implementer implemented OnInvokeContextCreated and returned true there
-	 *
-	 * @param pInvokeContext - the context that is about to get deleted
-	 */
-	virtual void OnInvokeContextRunsOutOfScope(SnaccInvokeContext* pInvokeContext) {};
-
-	/*
-	 * This callback provides statistic data for inbound messages
-	 * The idea is that a logic behind the callback is able to collect message durations, payload sizes, amount of calls etc.
-	 *
-	 * uiOperationID - the called OperationID (The called method may query SnaccRoseOperationLookup to get the name if needed)
-	 * ulInboundPayLoadSize - the inbound message size
-	 * duration - how long it took to process the message internally
-	 * ulResponsePayloadSize - the size of the response message (optional as events provide no response data)
-	 */
-	virtual void OnInboundMessageProcessed(unsigned int uiOperationID, unsigned long ulInboundPayLoadSize, std::chrono::milliseconds duration, std::optional<unsigned long> ulResponsePayloadSize)
-	{
-	}
-
-	/*
-	 * This callback provides statistic data for inbound messages
-	 * The idea is that a logic behind the callback is able to collect
-	 *
-	 * uiOperationID - the called OperationID (The called method may query SnaccRoseOperationLookup to get the name if needed)
-	 * ulOutboundPayLoadSize - the outbound message size
-	 * duration - how long it took to process the message on the other size (optional as events will not provide a respsone)
-	 * ulResponsePayloadSize - the size of the response message (optional as events provide no response data)
-	 * bTimedOut - true in case the request timed out (duration is then filled with the timeout value)
-	 */
-	virtual void OnOutboundMessageProcessed(unsigned int uiOperationID, unsigned long ulOutboundPayLoadSize, std::optional<std::chrono::milliseconds> duration, std::optional<unsigned long> ulResponsePayloadSize, bool bTimedOut = false)
-	{
-	}
+	void OnInvokeProcessed(std::shared_ptr<const SnaccTelemetryData> data) override;
 
 private:
 	/*! The ROSE component messages.
 		These are called from the OnROSEMessage.
 		Do not dete the parameters. The functions are called
 		before the CompleteOperation */
-	virtual void OnInvokeMessage(const SNACC::ROSEMessage* pMessage);
-	virtual void OnResultMessage(const SNACC::ROSEResult* pResult);
-	virtual void OnErrorMessage(const SNACC::ROSEError* pError);
-	virtual void OnRejectMessage(const SNACC::ROSEReject* pReject);
+	virtual void OnInvokeMessage(SNACC::ROSEMessage* pMessage, unsigned long lMessageSize);
+	virtual void OnResultMessage(SNACC::ROSEResult* pResult, unsigned long lMessageSize);
+	virtual void OnErrorMessage(SNACC::ROSEError* pError, unsigned long lMessageSize);
+	virtual void OnRejectMessage(SNACC::ROSEReject* pReject, unsigned long lMessageSize);
 
+	// The central process wide telemetry callback
+	static inline SnaccTelemetryCallback* m_pTelemetryCallback{};
+
+	/* The name of the concrete class. This is used for the static global telemetry callback when reporting telemetry to differ between different SnaccROSEBase inheriting classes */
+	const std::wstring m_strClassName;
 	/*! Maximum wait time (milliseconds) for a function to return default: 20000 ms*/
-	long m_lMaxInvokeWait = 20000;
+	long m_lMaxInvokeWait{20000};
 	/*! Are we currently active or was StopProcessing called */
-	bool m_bProcessingAllowed = false;
+	bool m_bProcessingAllowed{};
 	/*! The counter for the InvokeIds */
-	long m_lInvokeCounter = 0;
+	long m_lInvokeCounter{};
 	/*! The guard for m_bProcessingAllowed and SnaccROSEPendingOperationMap */
 	std::mutex m_InternalProtectMutex;
 	/*! If set, the open file where we append log data to. The pointer is created with ConfigureFileLogging() */
-	FILE* m_pAsnLogFile = nullptr;
+	FILE* m_pAsnLogFile{};
 	/*! true if the logfile already contains data, false if not */
-	bool m_bAsnLogFileContainsData = false;
+	bool m_bAsnLogFileContainsData{};
 	/*! true if every write to the logger shall get flushed */
-	bool m_bFlushEveryWrite = false;
+	bool m_bFlushEveryWrite{};
 	/*! Mutex to access the logging function (serialize multiple threads to it) */
 	std::mutex m_mtxLogFile;
 
-	void AddPendingOperation(int invokeID, SnaccROSEPendingOperation* pOperation);
+	SnaccROSEPendingOperation& AddPendingOperation(int invokeID, unsigned int uiOperationID, const char* szOperationName);
 	void RemovePendingOperation(int invokeID);
 	/*! Pending Operation result has been received.
 		Attention: The pMessage Objekt will be taken over from the
 		SnaccROSEPendingOperation Object and deleted in the end. */
-	bool CompletePendingOperation(int invokeID, const SNACC::ROSEMessage* pMessage);
+	bool CompletePendingOperation(int invokeID, const SNACC::ROSEMessage* pMessage, unsigned long ulMessageSize);
+	bool GetPendingOperationTelemetryInfo(int invokeID, unsigned int& uiOperationID, std::string& strOperationName);
+	static long GetRejectResultCode(const SNACC::ROSEReject* pReject);
+	static long GetRejectResultCode(const SNACC::ROSEReject* pReject, SnaccInvokeContext& ctx);
+	static long DecodeResponse(const SNACC::ROSEMessage* pResponse, SNACC::ROSEResult** ppResult, SNACC::ROSEError** ppError, SnaccInvokeContext& ctx);
 	void CompleteAllPendingOperations();
 
 	SnaccROSEPendingOperationMap m_PendingOperations;
@@ -430,10 +404,13 @@ private:
 	const std::set<int> m_multithreadInvokeIDs;
 
 	// Outbound Data Interface (optional)
-	ISnaccROSETransport* m_pTransport = NULL;
+	ISnaccROSETransport* m_pTransport{};
 
 	// Transport Encoding to be used
-	SNACC::TransportEncoding m_eTransportEncoding = SNACC::TransportEncoding::BER;
+	SNACC::TransportEncoding m_eTransportEncoding{SNACC::TransportEncoding::UNKNOWN};
+
+	// Detects the encoding from the transport data (used for inbound data)
+	SNACC::TransportEncoding DetectEncoding(const char* lpBytes, unsigned long ulSize) const;
 
 	// Get Length of JSON Header J1235{} )
 	int GetJsonHeaderLen(const char* lpBytes, unsigned long iLength);
@@ -446,9 +423,9 @@ private:
 	 *
 	 * pInvoke - the invoke to send
 	 * szOperationName - the operationName (for logging purposes)
-	 * pCtx - contextual data for the invoke
+	 * ctx - contextual data for the invoke
 	 */
-	long Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext* pCtx = nullptr);
+	long Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext& ctx, size_t* pstRequestData = nullptr);
 };
 
 #endif //_SnaccROSEBase_h_

--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -1,6 +1,8 @@
 #ifndef _SnaccROSEInterfaces_h_
 #define _SnaccROSEInterfaces_h_
 
+#include <functional>
+#include <memory>
 #include <string>
 
 namespace SNACC
@@ -12,6 +14,8 @@ namespace SNACC
 	class ROSEError;
 	class ROSEReject;
 	class InvokeProblem;
+	class ROSEAuthRequest;
+	class ROSEAuthResult;
 
 	enum class InvokeResult
 	{
@@ -22,12 +26,15 @@ namespace SNACC
 
 	enum class TransportEncoding
 	{
+		// An inbound connection initially has UNKNOWN until the stack has determined the encoding
+		// An outbound connection must set the encoding, otherwise the invoke will get rejected
+		UNKNOWN = 0,
 		// Transport Encoding Basic Encoding Rules (Binary)
-		BER = 0,
+		BER = 1,
 		// Transport Encoding JSON (Text)
-		JSON = 1,
+		JSON = 2,
 		// Transport Encoding JSON (Text), but without a framing header (J0000XXX{...})
-		JSON_NO_HEADING = 2
+		JSON_NO_HEADING = 3
 	};
 
 	enum class EAsnLogLevel
@@ -97,8 +104,11 @@ const long ROSE_REJECT_STARTSSLREQUIRED = 0x00000600;
 const long ROSE_REJECT_AUTHENTICATIONINCOMPLETE = 0x00000700;
 //! Authentication Failed
 const long ROSE_REJECT_AUTHENTICATIONFAILED = 0x00000800;
+
 //! Async Operation - This is not really a reject, the result will be sent async by the implentor
-const long ROSE_REJECT_ASYNCOPERATION = 0x00000900;
+//! NOT used therefore commented out
+// const long ROSE_REJECT_ASYNCOPERATION = 0x00000900;
+
 //! Server busy authentication rejected
 const long ROSE_REJECT_AUTHENTICATION_SERVER_BUSY = 0x00000A00;
 //! User temporary locked out due to to many failed authentication attempts
@@ -114,13 +124,69 @@ const long ROSE_REJECT_ARGUMENT_MISSING = 0x00000D00;
 const long ROSE_ERROR_VALUE = 0x00001000;
 
 class SnaccROSEBase;
-class SnaccInvokeContext;
+
+enum class SnaccInvokeDirection
+{
+	INBOUND = 0,
+	OUTBOUND = 1
+};
+
+class SnaccInvokeContextInit
+{
+public:
+	SnaccInvokeContextInit(SnaccInvokeDirection direction, SNACC::ROSEInvoke* pInvoke, const char* szOperationName = nullptr);
+
+	const SnaccInvokeDirection m_direction{};
+	const SNACC::ROSEInvoke* m_pInvoke{};
+	const std::string m_strOperationName;
+};
+
+class SnaccInvokeContext
+{
+public:
+	static std::shared_ptr<SnaccInvokeContext> Create(const SnaccInvokeContextInit& init);
+	virtual std::shared_ptr<SnaccInvokeContext> Clone() const;
+
+	SnaccInvokeContext& operator=(const SnaccInvokeContext&) = delete;
+	SnaccInvokeContext(SnaccInvokeContext&&) = delete;
+	SnaccInvokeContext& operator=(SnaccInvokeContext&&) = delete;
+	virtual ~SnaccInvokeContext();
+
+	// Called immediately before the context is transferred into telemetry retention.
+	// Override if derived types keep borrowed data that must be detached or copied.
+	virtual void PrepareForTelemetry();
+
+	// Meaning in OnInvoke_: Authentication Header from the ROSE Invoke (Pointer to the object in the invoke)
+	// Meaning in Invoke_: Authentication Header that is dispatched along with the invoke (create it with new, cleanup is done inside)
+	// SNACC::ROSEAuthRequest* pInvokeAuth{};
+
+	// Meaning in OnInvoke_: Authentication Header, which is returned in the reject if the method returnReject returns must be created with new, is cleaned up itself
+	// Meaning in Invoke_: If the method returnsReject, this member contains the optional reject authentication (only if SNACC_REJECT_AUTH_INCOMPLETE)
+	SNACC::ROSEAuthResult* m_pRejectAuth{};
+
+	// Reject Result Code: 0 or ROSE_REJECT_AUTHENTICATIONFAILED or ROSE_REJECT_AUTHENTICATIONINCOMPLETE
+	// Meaning in Invoke_: If the method returns returnReject, this member contains ROSE_REJECT_AUTHENTICATIONINCOMPLETE or ROSE_REJECT_AUTHENTICATIONFAILED if the authentication was not successful
+	long m_lRejectResult{};
+
+	// This flag is set to true in case the invoked method replied with an error instead of a result
+	bool m_bResponseIsError{};
+
+	// Meaning in OnInvoke_: Original invoke (borrowed, cleared before telemetry retention)
+	// SNACC::ROSEInvoke* pInvoke{};
+
+protected:
+	explicit SnaccInvokeContext(const SnaccInvokeContextInit& init);
+	// Allows derived context types to copy the base invoke-context state into a richer concrete type.
+	SnaccInvokeContext(const SnaccInvokeContext& other);
+};
 
 /*! SnaccROSESender is the interface that is used to dispatch inbound invokes and events
  */
 class SnaccROSESender
 {
 public:
+	virtual std::shared_ptr<SnaccInvokeContext> CreateInvokeContext(const SnaccInvokeContextInit& init) = 0;
+
 	/*! Increment invoke counter and return InvokeID */
 	virtual long GetNextInvokeID() = 0;
 
@@ -143,15 +209,17 @@ public:
 	/** An invoke that is send to the other side. Should only be called by the ROSE stub itself generated files
 	 *
 	 * pInvoke - the invoke payload (it is put into a ROSEMessage in the function)
-	 * pResponse - the response payload (is handled afterwards in the HandleInvokeResult method
+	 * result - decoded result payload in case a result response is received
+	 * error - decoded error payload in case an error response is received
 	 * szOperationName - the operationName (for logging purposes)
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don´t care about the result))
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don´t care about the result))
-	 * pCtx - contextual data for the invoke
+	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don't care about the result))
+	 * pCtx - contextual data for the invoke. The caller may keep another shared reference
+	 *        to inspect changes after the call.
 	 */
-	virtual long SendInvoke(SNACC::ROSEInvoke* pInvoke, const SNACC::ROSEMessage** pResponse, const char* szOperationName, int iTimeout = -1, SnaccInvokeContext* pCtx = nullptr) = 0;
+	virtual long SendInvoke(SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* result, SNACC::AsnType* error, const char* szOperationName, int iTimeout = -1, std::shared_ptr<SnaccInvokeContext> pCtx = {}) = 0;
 
-	/** Handles the response payload of the SendInvoke method. Retrieves the result or error from the response
+	/**
+	 * Handles the response payload of the SendInvoke method. Retrieves the result or error from the response
 	 *
 	 * lRoseResult - the result of the SendInvoke method
 	 * pResponseMsg - the response message as provided by the SendInvoke method
@@ -159,17 +227,19 @@ public:
 	 * error - the error object (Base type pointer, the caller of the invoke provides the proper type)
 	 * pCtx - contextual data for the invoke
 	 */
-	virtual long HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage* pResponseMsg, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext* cxt) = 0;
+	virtual long HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage* pResponseMsg, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext& ctx) = 0;
 
-	/** Encodes the result or error from an OnInvoke request. Retrieves the result or error from the response
+	/**
+	 * Encodes the result or error from an OnInvoke request. Retrieves the result or error from the response
 	 *
 	 * invokeResult - the result of the OnInvoke method
+	 * pInvoke - the original invoke
+	 * ctx - contextual data for the invoke
 	 * strResponse - the encoded result to put it on the transport
 	 * result - the result object (Base type pointer, the caller of the invoke provides the proper type)
 	 * error - the error object (Base type pointer, the caller of the invoke provides the proper type)
-	 * pCtx - contextual data for the invoke
 	 */
-	virtual long HandleOnInvokeResult(SNACC::InvokeResult invokeResult, std::string& strResponse, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext* cxt) = 0;
+	virtual long HandleOnInvokeResult(SNACC::InvokeResult invokeResult, const SNACC::ROSEInvoke* pInvoke, SnaccInvokeContext& ctx, std::string& strResponse, SNACC::AsnType* pResult, SNACC::AsnType* pError) = 0;
 
 	/**
 	 * Decodes an invoke and properly handles logging for it
@@ -183,15 +253,47 @@ public:
 	 *
 	 * pInvoke - the invoke payload (it is put into a ROSEMessage in the function)
 	 * szOperationName - the operationName (for logging purposes)
-	 * pCtx - contextual data for the invoke
+	 * pCtx - contextual data for the invoke. The caller may keep another shared reference
+	 *        to inspect changes after the call.
 	 */
-	virtual long SendEvent(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext* pCtx = nullptr) = 0;
+	virtual long SendEvent(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx = {}) = 0;
 
-	/* Send a Result Message. */
-	virtual long SendResult(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, const wchar_t* szSessionID = 0) = 0;
+	/*
+	 * Encodes a result as repsonse to an invoke
+	 *
+	 * uiInvokeID - the inbound invoke that we send the error for
+	 * pResult - the actual result object
+	 * strResponse - the encoded response data to send via the transport layer
+	 * szSessionID - the SessionID (this propery is filled by subclassing from the concrete class in case we are handling multiple clients via one connection)
+	 */
+	virtual long EncodeResult(unsigned int uiInvokeID, SNACC::AsnType* pResult, std::string& strResponse, const wchar_t* szSessionID = nullptr) = 0;
 
-	/* Encode a error message */
-	virtual long EncodeError(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pError, const wchar_t* szSessionID, std::string& strResponse) = 0;
+	/*
+	 * Encodes an error as repsonse to an invoke
+	 *
+	 * uiInvokeID - the inbound invoke that we send the error for
+	 * pError - the actual error object
+	 * strResponse - the encoded response data to send via the transport layer
+	 * szSessionID - the SessionID (this propery is filled by subclassing from the concrete class in case we are handling multiple clients via one connection)
+	 */
+	virtual long EncodeError(unsigned int uiInvokeID, SNACC::AsnType* pError, std::string& strResponse, const wchar_t* szSessionID = nullptr) = 0;
+};
+
+class SnaccScopedInvokeMessage
+{
+public:
+	explicit SnaccScopedInvokeMessage(long invokeID, unsigned int uiOperationID, SNACC::AsnType* argument);
+	SnaccScopedInvokeMessage(const SnaccScopedInvokeMessage&) = delete;
+	SnaccScopedInvokeMessage& operator=(const SnaccScopedInvokeMessage&) = delete;
+	SnaccScopedInvokeMessage(SnaccScopedInvokeMessage&&) = delete;
+	SnaccScopedInvokeMessage& operator=(SnaccScopedInvokeMessage&&) = delete;
+	~SnaccScopedInvokeMessage();
+
+	SNACC::ROSEInvoke* GetPtr();
+	const SNACC::ROSEInvoke* GetPtr() const;
+
+private:
+	std::unique_ptr<SNACC::ROSEInvoke> m_pInvoke;
 };
 
 /*! ISnaccROSEInvoke is the base class
@@ -219,7 +321,7 @@ class ISnaccROSETransport
 public:
 	/* Output of the binary data.
 		Override this function to send the data to the transport layer. */
-	virtual long SendBinaryDataBlockEx(const char* lpBytes, unsigned long lSize, SnaccInvokeContext* pCtx) = 0;
+	virtual long SendBinaryDataBlockEx(const char* lpBytes, size_t size, SnaccInvokeContext& ctx) = 0;
 };
 
 #endif //_SnaccROSEInterfaces_h_

--- a/cpp-lib/include/SnaccTelemetry.h
+++ b/cpp-lib/include/SnaccTelemetry.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include "SnaccROSEInterfaces.h"
+
+/**
+ * Carries telemetry for one ROSE request lifecycle.
+ *
+ * The object can represent inbound or outbound traffic and covers both invokes and
+ * events. It is created when the library starts handling or sending a request and is
+ * finalized once the local lifecycle has completed.
+ *
+ * The request metadata captured at construction time is immutable. Completion data
+ * such as duration, response size, outcome, and the final ROSE result code are
+ * populated by `finalize()`.
+ *
+ * Duration always represents the local lifecycle time inside this library instance.
+ * For inbound requests it is the handling time, for outbound invokes it usually
+ * includes waiting for the response, and for outbound events it only reflects the
+ * local send/encode time.
+ *
+ * The object is intended to be shared with telemetry consumers as
+ * `std::shared_ptr<const SnaccTelemetryData>` so callbacks can inspect the data
+ * without mutating it.
+ */
+class SnaccTelemetryData
+{
+public:
+	enum class Direction
+	{
+		INBOUND = 0,
+		OUTBOUND = 1
+	};
+
+	enum class Outcome
+	{
+		// The invoked method returned a normal result.
+		RESULT = 0,
+		// The invoked method returned an application error.
+		ERR = 1,
+		// The invoke could not be handled and therefore resulted in a reject.
+		REJECT = 2,
+		// The inbound message was an event and therefore intentionally produced no response.
+		EVENT = 3,
+		// The local lifecycle completed abnormally (exception, unable to decode, unable to encode, sending failed etc.)
+		UNHANDLED = 4
+	};
+
+	// Stage identifies the lifecycle area in which the telemetry record was finalized.
+	enum class Stage
+	{
+		// Fallback value in case the stage could not be determined.
+		UNKNOWN = 0,
+		// Finalized while decoding an inbound transport payload.
+		INBOUND_DECODE = 1,
+		// Finalized while handling an inbound invoke or event.
+		INBOUND_INVOKE = 2,
+		// Finalized for an inbound result/error/reject message.
+		INBOUND_RESPONSE = 3,
+		// Finalized while encoding or sending an outbound message.
+		OUTBOUND_SEND = 4,
+		// Finalized while waiting for the reply to an outbound invoke.
+		OUTBOUND_WAIT = 5
+	};
+
+	// Reason captures the concrete condition that led to the final outcome.
+	enum class Reason
+	{
+		// No more specific reason was recorded.
+		NONE = 0,
+		// The local invoke handler produced a normal result.
+		LOCAL_RESULT = 1,
+		// The local invoke handler produced an application error.
+		LOCAL_ERROR = 2,
+		// The local side generated and successfully sent a reject.
+		LOCAL_REJECT = 3,
+		// The local side handled or sent an event without expecting a response.
+		LOCAL_EVENT = 4,
+		// A normal result message was received from the remote side.
+		REMOTE_RESULT = 5,
+		// An application error message was received from the remote side.
+		REMOTE_ERROR = 6,
+		// A reject message was received from the remote side.
+		REMOTE_REJECT = 7,
+		// The payload could not be decoded.
+		DECODE_FAILED = 8,
+		// A response could not be encoded.
+		ENCODE_FAILED = 9,
+		// Sending the payload through the transport failed.
+		SEND_FAILED = 10,
+		// Waiting for an outbound invoke response timed out.
+		TIMEOUT = 11,
+		// The lifecycle ended because processing was stopped.
+		SHUTDOWN = 12,
+		// The received response message did not match the expected shape.
+		INVALID_RESPONSE = 13,
+		// Waiting for a reply was intentionally skipped.
+		WAIT_SKIPPED = 14,
+		// The local invoke handler raised an exception and the stub replied with a reject.
+		INVOKE_EXCEPTION = 15,
+		// Fallback value in case the exact failure reason could not be classified.
+		UNKNOWN_FAILURE = 16
+	};
+
+	// Returns a short debug-friendly text for the enum value.
+	static const char* GetDebugText(Direction direction);
+	static const char* GetDebugText(Outcome outcome);
+	static const char* GetDebugText(Stage stage);
+	static const char* GetDebugText(Reason reason);
+
+	// Creates the telemetry object in shared ownership so it can be forwarded safely.
+	static std::shared_ptr<SnaccTelemetryData> Create(Direction direction, unsigned int uiOperationID, const char* szOperationName, size_t stRequestData, std::chrono::steady_clock::time_point chronoCreated = std::chrono::steady_clock::now());
+	static std::shared_ptr<SnaccTelemetryData> CreateFinalized(Direction direction, unsigned int uiOperationID, const char* szOperationName, size_t stRequestData, Outcome outcome, Stage stage, Reason reason,
+		long lRoseResult,
+		std::optional<size_t> stResponseData = std::nullopt, std::shared_ptr<SnaccInvokeContext> pctx = {},
+		std::chrono::steady_clock::time_point chronoCreated = std::chrono::steady_clock::now());
+
+	// Finalizes the telemetry data once the local request lifecycle has completed.
+	// For events pass Outcome::EVENT and leave stResponseData empty.
+	void finalize(Outcome outcome, Stage stage, Reason reason, std::optional<long> lRoseResult = std::nullopt, std::optional<size_t> stResponseData = std::nullopt,
+		std::shared_ptr<SnaccInvokeContext> pctx = {});
+
+	// Immutable request metadata captured when the lifecycle starts.
+	const Direction m_Direction{};
+	const unsigned int m_uiOperationID{};
+	const std::string m_strOperationName{};
+	const size_t m_stRequestData{};
+	const std::chrono::steady_clock::time_point m_ChronoCreated;
+
+	// Outcome data filled once processing completes.
+	std::chrono::milliseconds m_Duration{};
+	std::optional<size_t> m_stResponseData{};
+	std::shared_ptr<const SnaccInvokeContext> m_pctx{};
+	Outcome m_Outcome{};
+	Stage m_Stage{};
+	Reason m_Reason{};
+	std::optional<long> m_lRoseResult{};
+
+private:
+	bool m_bFinalized{};
+
+	// Use Create() so the object is consistently handed around in shared ownership.
+	SnaccTelemetryData(Direction direction, unsigned int uiOperationID, const char* szOperationName, size_t stRequestData, std::chrono::steady_clock::time_point chronoCreated);
+};
+
+class SnaccTelemetryCallback
+{
+public:
+	virtual ~SnaccTelemetryCallback() = default;
+
+	/*
+	 * Called after a ROSE message lifecycle has been processed by the stub.
+	 * The callback receives a read-only telemetry object containing request metadata
+	 * and the final processing outcome so implementations can record durations,
+	 * payload sizes, result distribution, handled events, and the
+	 * direction of the processed message.
+	 */
+	virtual void OnInvokeProcessed(std::shared_ptr<const SnaccTelemetryData>) = 0;
+};

--- a/cpp-lib/src/SNACCDeprecated.cpp
+++ b/cpp-lib/src/SNACCDeprecated.cpp
@@ -28,14 +28,15 @@ void SNACCDeprecated::DeprecatedASN1Object(const long long i64DeprecatedSince, c
 	m_pCallback->DeprecatedASN1Object(i64DeprecatedSince, szModuleName, szObjectName, callStack);
 }
 
-void SNACCDeprecated::DeprecatedASN1Method(const long long i64DeprecatedSince, const char* szModuleName, const char* szMethodName, const SNACCDeprecatedNotifyCallDirection direction, const SnaccInvokeContext* pContext /* = NULL */)
+void SNACCDeprecated::DeprecatedASN1Method(const long long i64DeprecatedSince, const char* szModuleName, const char* szMethodName, const SNACCDeprecatedNotifyCallDirection direction,
+	SnaccInvokeContext& ctx)
 {
 	if (!m_pCallback)
 		return;
 
 	std::list<std::string> callStack = GetStackTrace(2);
 
-	m_pCallback->DeprecatedASN1Method(i64DeprecatedSince, szModuleName, szMethodName, direction, callStack, pContext);
+	m_pCallback->DeprecatedASN1Method(i64DeprecatedSince, szModuleName, szMethodName, direction, callStack, ctx);
 }
 
 std::list<std::string> SNACCDeprecated::GetStackTrace(int remove /*= 1*/)

--- a/cpp-lib/src/SNACCROSE.cpp
+++ b/cpp-lib/src/SNACCROSE.cpp
@@ -808,8 +808,8 @@ ROSEError::~ROSEError()
 // [PrintInit]
 void ROSEError::Init()
 {
-	sessionID = NULL;
-	error = NULL;
+	sessionID = nullptr;
+	error = nullptr;
 }
 
 // [PrintClear]
@@ -818,12 +818,12 @@ void ROSEError::Clear()
 	if (sessionID)
 	{
 		delete sessionID;
-		sessionID = NULL;
+		sessionID = nullptr;
 	}
 	if (error)
 	{
 		delete error;
-		error = NULL;
+		error = nullptr;
 	}
 }
 
@@ -848,7 +848,7 @@ ROSEError& ROSEError::operator=(const ROSEError& that)
 		else if (sessionID)
 		{
 			delete sessionID;
-			sessionID = NULL;
+			sessionID = nullptr;
 		}
 		invokedID = that.invokedID;
 		error_value = that.error_value;
@@ -861,7 +861,7 @@ ROSEError& ROSEError::operator=(const ROSEError& that)
 		else if (error)
 		{
 			delete error;
-			error = NULL;
+			error = nullptr;
 		}
 	}
 
@@ -1187,7 +1187,7 @@ ROSEAuthRequest::~ROSEAuthRequest()
 // [PrintInit]
 void ROSEAuthRequest::Init()
 {
-	context = NULL;
+	context = nullptr;
 }
 
 // [PrintClear]
@@ -1197,7 +1197,7 @@ void ROSEAuthRequest::Clear()
 	if (context)
 	{
 		delete context;
-		context = NULL;
+		context = nullptr;
 	}
 }
 
@@ -1223,7 +1223,7 @@ ROSEAuthRequest& ROSEAuthRequest::operator=(const ROSEAuthRequest& that)
 		else if (context)
 		{
 			delete context;
-			context = NULL;
+			context = nullptr;
 		}
 	}
 
@@ -1453,7 +1453,7 @@ ROSEAuthResult::~ROSEAuthResult()
 // [PrintInit]
 void ROSEAuthResult::Init()
 {
-	context = NULL;
+	context = nullptr;
 }
 
 // [PrintClear]
@@ -1462,7 +1462,7 @@ void ROSEAuthResult::Clear()
 	if (context)
 	{
 		delete context;
-		context = NULL;
+		context = nullptr;
 	}
 }
 
@@ -1488,7 +1488,7 @@ ROSEAuthResult& ROSEAuthResult::operator=(const ROSEAuthResult& that)
 		else if (context)
 		{
 			delete context;
-			context = NULL;
+			context = nullptr;
 		}
 	}
 
@@ -1718,11 +1718,11 @@ ROSEInvoke::~ROSEInvoke()
 // [PrintInit]
 void ROSEInvoke::Init()
 {
-	sessionID = NULL;
-	linked_ID = NULL;
-	operationName = NULL;
-	authentication = NULL;
-	argument = NULL;
+	sessionID = nullptr;
+	linked_ID = nullptr;
+	operationName = nullptr;
+	authentication = nullptr;
+	argument = nullptr;
 }
 
 // [PrintClear]
@@ -1731,27 +1731,27 @@ void ROSEInvoke::Clear()
 	if (sessionID)
 	{
 		delete sessionID;
-		sessionID = NULL;
+		sessionID = nullptr;
 	}
 	if (linked_ID)
 	{
 		delete linked_ID;
-		linked_ID = NULL;
+		linked_ID = nullptr;
 	}
 	if (operationName)
 	{
 		delete operationName;
-		operationName = NULL;
+		operationName = nullptr;
 	}
 	if (authentication)
 	{
 		delete authentication;
-		authentication = NULL;
+		authentication = nullptr;
 	}
 	if (argument)
 	{
 		delete argument;
-		argument = NULL;
+		argument = nullptr;
 	}
 }
 
@@ -1776,7 +1776,7 @@ ROSEInvoke& ROSEInvoke::operator=(const ROSEInvoke& that)
 		else if (sessionID)
 		{
 			delete sessionID;
-			sessionID = NULL;
+			sessionID = nullptr;
 		}
 		invokeID = that.invokeID;
 		if (that.linked_ID)
@@ -1788,7 +1788,7 @@ ROSEInvoke& ROSEInvoke::operator=(const ROSEInvoke& that)
 		else if (linked_ID)
 		{
 			delete linked_ID;
-			linked_ID = NULL;
+			linked_ID = nullptr;
 		}
 		if (that.operationName)
 		{
@@ -1799,7 +1799,7 @@ ROSEInvoke& ROSEInvoke::operator=(const ROSEInvoke& that)
 		else if (operationName)
 		{
 			delete operationName;
-			operationName = NULL;
+			operationName = nullptr;
 		}
 		if (that.authentication)
 		{
@@ -1810,7 +1810,7 @@ ROSEInvoke& ROSEInvoke::operator=(const ROSEInvoke& that)
 		else if (authentication)
 		{
 			delete authentication;
-			authentication = NULL;
+			authentication = nullptr;
 		}
 		operationID = that.operationID;
 		if (that.argument)
@@ -1822,7 +1822,7 @@ ROSEInvoke& ROSEInvoke::operator=(const ROSEInvoke& that)
 		else if (argument)
 		{
 			delete argument;
-			argument = NULL;
+			argument = nullptr;
 		}
 	}
 
@@ -2282,8 +2282,8 @@ ROSEResult::~ROSEResult()
 // [PrintInit]
 void ROSEResult::Init()
 {
-	sessionID = NULL;
-	result = NULL;
+	sessionID = nullptr;
+	result = nullptr;
 }
 
 // [PrintClear]
@@ -2292,12 +2292,12 @@ void ROSEResult::Clear()
 	if (sessionID)
 	{
 		delete sessionID;
-		sessionID = NULL;
+		sessionID = nullptr;
 	}
 	if (result)
 	{
 		delete result;
-		result = NULL;
+		result = nullptr;
 	}
 }
 
@@ -2322,7 +2322,7 @@ ROSEResult& ROSEResult::operator=(const ROSEResult& that)
 		else if (sessionID)
 		{
 			delete sessionID;
-			sessionID = NULL;
+			sessionID = nullptr;
 		}
 		invokeID = that.invokeID;
 		if (that.result)
@@ -2334,7 +2334,7 @@ ROSEResult& ROSEResult::operator=(const ROSEResult& that)
 		else if (result)
 		{
 			delete result;
-			result = NULL;
+			result = nullptr;
 		}
 	}
 
@@ -2984,10 +2984,10 @@ ROSEReject::~ROSEReject()
 // [PrintInit]
 void ROSEReject::Init()
 {
-	sessionID = NULL;
-	reject = NULL;
-	details = NULL;
-	authentication = NULL;
+	sessionID = nullptr;
+	reject = nullptr;
+	details = nullptr;
+	authentication = nullptr;
 }
 
 // [PrintClear]
@@ -2996,23 +2996,23 @@ void ROSEReject::Clear()
 	if (sessionID)
 	{
 		delete sessionID;
-		sessionID = NULL;
+		sessionID = nullptr;
 	}
 	invokedID.Clear();
 	if (reject)
 	{
 		delete reject;
-		reject = NULL;
+		reject = nullptr;
 	}
 	if (details)
 	{
 		delete details;
-		details = NULL;
+		details = nullptr;
 	}
 	if (authentication)
 	{
 		delete authentication;
-		authentication = NULL;
+		authentication = nullptr;
 	}
 }
 
@@ -3037,7 +3037,7 @@ ROSEReject& ROSEReject::operator=(const ROSEReject& that)
 		else if (sessionID)
 		{
 			delete sessionID;
-			sessionID = NULL;
+			sessionID = nullptr;
 		}
 		invokedID = that.invokedID;
 		if (that.reject)
@@ -3049,7 +3049,7 @@ ROSEReject& ROSEReject::operator=(const ROSEReject& that)
 		else if (reject)
 		{
 			delete reject;
-			reject = NULL;
+			reject = nullptr;
 		}
 		if (that.details)
 		{
@@ -3060,7 +3060,7 @@ ROSEReject& ROSEReject::operator=(const ROSEReject& that)
 		else if (details)
 		{
 			delete details;
-			details = NULL;
+			details = nullptr;
 		}
 		if (that.authentication)
 		{
@@ -3071,7 +3071,7 @@ ROSEReject& ROSEReject::operator=(const ROSEReject& that)
 		else if (authentication)
 		{
 			delete authentication;
-			authentication = NULL;
+			authentication = nullptr;
 		}
 	}
 

--- a/cpp-lib/src/SNACCROSE.cpp
+++ b/cpp-lib/src/SNACCROSE.cpp
@@ -95,6 +95,8 @@ void ROSERejectChoice::Clear()
 				invokednull = nullptr;
 			}
 			break;
+		default:
+			break;
 	}
 	choiceId = notinitialized;
 }
@@ -121,6 +123,8 @@ ROSERejectChoice& ROSERejectChoice::operator=(const ROSERejectChoice& that)
 					break;
 				case invokednullCid:
 					invokednull = new AsnNull(*that.invokednull);
+					break;
+				default:
 					break;
 			}
 		}
@@ -155,13 +159,13 @@ AsnLen ROSERejectChoice::BEncContent(AsnBuf& _b) const
 			l = invokedID->BEncContent(_b);
 			l += BEncDefLen(_b, l);
 			l += BEncTag1(_b, UNIV, PRIM, INTEGER_TAG_CODE);
-		break;
+			break;
 		case invokednullCid:
 			l = invokednull->BEncContent(_b);
 			BEncDefLenTo127(_b, l);
 			l++;
 			l += BEncTag1(_b, UNIV, PRIM, NULLTYPE_TAG_CODE);
-		break;
+			break;
 		default:
 			throw EXCEPT("Choice is empty", ENCODE_ERROR);
 	}
@@ -178,15 +182,14 @@ void ROSERejectChoice::BDecContent(const AsnBuf &_b, AsnTag tag, AsnLen elmtLen0
 			choiceId = invokedIDCid;
 			invokedID = new AsnInt;
 			invokedID->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(UNIV, PRIM, NULLTYPE_TAG_CODE):
 			choiceId = invokednullCid;
 			invokednull = new AsnNull;
 			invokednull->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		default:
 			throw InvalidTagException(typeName(), tag, STACK_ENTRY);
-		break;
 	}
 }
 
@@ -259,22 +262,22 @@ void ROSERejectChoice::Print(std::ostream& os, unsigned short indent) const
 {
 	switch (choiceId)
 	{
-	case invokedIDCid:
-		os << "invokedID ";
-		if (invokedID)
-			invokedID->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case invokednullCid:
-		os << "invokednull ";
-		if (invokednull)
-			invokednull->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
+		case invokedIDCid:
+			os << "invokedID ";
+			if (invokedID)
+				invokedID->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case invokednullCid:
+			os << "invokednull ";
+			if (invokednull)
+				invokednull->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		default:
+			throw EXCEPT("Choice is empty", PARAMETER_ERROR);
 	} // end of switch
 } // end of ROSERejectChoice::Print()
 
@@ -295,20 +298,16 @@ void ROSERejectChoice::PrintXML(std::ostream& os, const char* lpszTitle) const
 			if (invokedID)
 				invokedID->PrintXML(os,"invokedID");
 			else
-			{
 				os << "<invokedID -- void3 -- /invokedID>" << std::endl;
-			}
-		break;
-
+			break;
 		case invokednullCid:
 			if (invokednull)
 				invokednull->PrintXML(os,"invokednull");
 			else
-			{
 				os << "<invokednull -- void3 -- /invokednull>" << std::endl;
-			}
-		break;
-
+			break;
+		default:
+			throw EXCEPT("Choice is empty", PARAMETER_ERROR);
 	} // end of switch
 	if (lpszTitle)
 		os << "</" << lpszTitle << ">";
@@ -2656,6 +2655,8 @@ void RejectProblem::Clear()
 				returnErrorProblem = nullptr;
 			}
 			break;
+		default:
+			break;
 	}
 	choiceId = notinitialized;
 }
@@ -2688,6 +2689,8 @@ RejectProblem& RejectProblem::operator=(const RejectProblem& that)
 					break;
 				case returnErrorProblemCid:
 					returnErrorProblem = new ReturnErrorProblem(*that.returnErrorProblem);
+					break;
+				default:
 					break;
 			}
 		}
@@ -2726,22 +2729,22 @@ AsnLen RejectProblem::BEncContent(AsnBuf& _b) const
 			l = generalProblem->BEncContent(_b);
 			l += BEncDefLen(_b, l);
 			l += BEncTag1(_b, CNTX, PRIM, 0);
-		break;
+			break;
 		case invokeProblemCid:
 			l = invokeProblem->BEncContent(_b);
 			l += BEncDefLen(_b, l);
 			l += BEncTag1(_b, CNTX, PRIM, 1);
-		break;
+			break;
 		case returnResultProblemCid:
 			l = returnResultProblem->BEncContent(_b);
 			l += BEncDefLen(_b, l);
 			l += BEncTag1(_b, CNTX, PRIM, 2);
-		break;
+			break;
 		case returnErrorProblemCid:
 			l = returnErrorProblem->BEncContent(_b);
 			l += BEncDefLen(_b, l);
 			l += BEncTag1(_b, CNTX, PRIM, 3);
-		break;
+			break;
 		default:
 			throw EXCEPT("Choice is empty", ENCODE_ERROR);
 	}
@@ -2758,25 +2761,24 @@ void RejectProblem::BDecContent(const AsnBuf &_b, AsnTag tag, AsnLen elmtLen0, A
 			choiceId = generalProblemCid;
 			generalProblem = new GeneralProblem;
 			generalProblem->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(CNTX, PRIM, 1):
 			choiceId = invokeProblemCid;
 			invokeProblem = new InvokeProblem;
 			invokeProblem->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(CNTX, PRIM, 2):
 			choiceId = returnResultProblemCid;
 			returnResultProblem = new ReturnResultProblem;
 			returnResultProblem->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(CNTX, PRIM, 3):
 			choiceId = returnErrorProblemCid;
 			returnErrorProblem = new ReturnErrorProblem;
 			returnErrorProblem->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		default:
 			throw InvalidTagException(typeName(), tag, STACK_ENTRY);
-		break;
 	}
 }
 
@@ -2871,38 +2873,36 @@ void RejectProblem::Print(std::ostream& os, unsigned short indent) const
 {
 	switch (choiceId)
 	{
-	case generalProblemCid:
-		os << "generalProblem ";
-		if (generalProblem)
-			generalProblem->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case invokeProblemCid:
-		os << "invokeProblem ";
-		if (invokeProblem)
-			invokeProblem->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case returnResultProblemCid:
-		os << "returnResultProblem ";
-		if (returnResultProblem)
-			returnResultProblem->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case returnErrorProblemCid:
-		os << "returnErrorProblem ";
-		if (returnErrorProblem)
-			returnErrorProblem->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
+		case generalProblemCid:
+			os << "generalProblem ";
+			if (generalProblem)
+				generalProblem->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case invokeProblemCid:
+			os << "invokeProblem ";
+			if (invokeProblem)
+				invokeProblem->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case returnResultProblemCid:
+			os << "returnResultProblem ";
+			if (returnResultProblem)
+				returnResultProblem->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case returnErrorProblemCid:
+			os << "returnErrorProblem ";
+			if (returnErrorProblem)
+				returnErrorProblem->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		default:
+			throw EXCEPT("Choice is empty", PARAMETER_ERROR);
 	} // end of switch
 } // end of RejectProblem::Print()
 
@@ -2923,38 +2923,28 @@ void RejectProblem::PrintXML(std::ostream& os, const char* lpszTitle) const
 			if (generalProblem)
 				generalProblem->PrintXML(os,"generalProblem");
 			else
-			{
 				os << "<generalProblem -- void3 -- /generalProblem>" << std::endl;
-			}
-		break;
-
+			break;
 		case invokeProblemCid:
 			if (invokeProblem)
 				invokeProblem->PrintXML(os,"invokeProblem");
 			else
-			{
 				os << "<invokeProblem -- void3 -- /invokeProblem>" << std::endl;
-			}
-		break;
-
+			break;
 		case returnResultProblemCid:
 			if (returnResultProblem)
 				returnResultProblem->PrintXML(os,"returnResultProblem");
 			else
-			{
 				os << "<returnResultProblem -- void3 -- /returnResultProblem>" << std::endl;
-			}
-		break;
-
+			break;
 		case returnErrorProblemCid:
 			if (returnErrorProblem)
 				returnErrorProblem->PrintXML(os,"returnErrorProblem");
 			else
-			{
 				os << "<returnErrorProblem -- void3 -- /returnErrorProblem>" << std::endl;
-			}
-		break;
-
+			break;
+		default:
+			throw EXCEPT("Choice is empty", PARAMETER_ERROR);
 	} // end of switch
 	if (lpszTitle)
 		os << "</" << lpszTitle << ">";
@@ -3488,6 +3478,8 @@ void ROSEMessage::Clear()
 				reject = nullptr;
 			}
 			break;
+		default:
+			break;
 	}
 	choiceId = notinitialized;
 }
@@ -3520,6 +3512,8 @@ ROSEMessage& ROSEMessage::operator=(const ROSEMessage& that)
 					break;
 				case rejectCid:
 					reject = new ROSEReject(*that.reject);
+					break;
+				default:
 					break;
 			}
 		}
@@ -3558,22 +3552,22 @@ AsnLen ROSEMessage::BEncContent(AsnBuf& _b) const
 			l = invoke->BEncContent(_b);
 			l += BEncConsLen(_b, l);
 			l += BEncTag1(_b, CNTX, CONS, 1);
-		break;
+			break;
 		case resultCid:
 			l = result->BEncContent(_b);
 			l += BEncConsLen(_b, l);
 			l += BEncTag1(_b, CNTX, CONS, 2);
-		break;
+			break;
 		case errorCid:
 			l = error->BEncContent(_b);
 			l += BEncConsLen(_b, l);
 			l += BEncTag1(_b, CNTX, CONS, 3);
-		break;
+			break;
 		case rejectCid:
 			l = reject->BEncContent(_b);
 			l += BEncConsLen(_b, l);
 			l += BEncTag1(_b, CNTX, CONS, 4);
-		break;
+			break;
 		default:
 			throw EXCEPT("Choice is empty", ENCODE_ERROR);
 	}
@@ -3590,25 +3584,24 @@ void ROSEMessage::BDecContent(const AsnBuf &_b, AsnTag tag, AsnLen elmtLen0, Asn
 			choiceId = invokeCid;
 			invoke = new ROSEInvoke;
 			invoke->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(CNTX, CONS, 2):
 			choiceId = resultCid;
 			result = new ROSEResult;
 			result->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(CNTX, CONS, 3):
 			choiceId = errorCid;
 			error = new ROSEError;
 			error->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		case MAKE_TAG_ID(CNTX, CONS, 4):
 			choiceId = rejectCid;
 			reject = new ROSEReject;
 			reject->BDecContent(_b, tag, elmtLen0, bytesDecoded);
-		break;
+			break;
 		default:
 			throw InvalidTagException(typeName(), tag, STACK_ENTRY);
-		break;
 	}
 }
 
@@ -3703,38 +3696,36 @@ void ROSEMessage::Print(std::ostream& os, unsigned short indent) const
 {
 	switch (choiceId)
 	{
-	case invokeCid:
-		os << "invoke ";
-		if (invoke)
-			invoke->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case resultCid:
-		os << "result ";
-		if (result)
-			result->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case errorCid:
-		os << "error ";
-		if (error)
-			error->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
-	case rejectCid:
-		os << "reject ";
-		if (reject)
-			reject->Print(os, indent);
-		else
-			os << "<CHOICE value is missing>\n";
-		break;
-
+		case invokeCid:
+			os << "invoke ";
+			if (invoke)
+				invoke->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case resultCid:
+			os << "result ";
+			if (result)
+				result->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case errorCid:
+			os << "error ";
+			if (error)
+				error->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		case rejectCid:
+			os << "reject ";
+			if (reject)
+				reject->Print(os, indent);
+			else
+				os << "<CHOICE value is missing>\n";
+			break;
+		default:
+			throw EXCEPT("Choice is empty", PARAMETER_ERROR);
 	} // end of switch
 } // end of ROSEMessage::Print()
 
@@ -3755,38 +3746,28 @@ void ROSEMessage::PrintXML(std::ostream& os, const char* lpszTitle) const
 			if (invoke)
 				invoke->PrintXML(os,"invoke");
 			else
-			{
 				os << "<invoke -- void3 -- /invoke>" << std::endl;
-			}
-		break;
-
+			break;
 		case resultCid:
 			if (result)
 				result->PrintXML(os,"result");
 			else
-			{
 				os << "<result -- void3 -- /result>" << std::endl;
-			}
-		break;
-
+			break;
 		case errorCid:
 			if (error)
 				error->PrintXML(os,"error");
 			else
-			{
 				os << "<error -- void3 -- /error>" << std::endl;
-			}
-		break;
-
+			break;
 		case rejectCid:
 			if (reject)
 				reject->PrintXML(os,"reject");
 			else
-			{
 				os << "<reject -- void3 -- /reject>" << std::endl;
-			}
-		break;
-
+			break;
+		default:
+			throw EXCEPT("Choice is empty", PARAMETER_ERROR);
 	} // end of switch
 	if (lpszTitle)
 		os << "</" << lpszTitle << ">";

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -10,28 +10,71 @@
 
 using namespace SNACC;
 
-SnaccInvokeContext::SnaccInvokeContext()
+SnaccInvokeContextInit::SnaccInvokeContextInit(SnaccInvokeDirection direction, SNACC::ROSEInvoke* pInvoke, const char* szOperationName /*= nullptr*/)
+	: m_direction(direction),
+	  m_pInvoke(pInvoke),
+	  m_strOperationName(szOperationName ? szOperationName : (pInvoke ? SnaccRoseOperationLookup::LookUpName(pInvoke->operationID) : nullptr))
 {
-	pInvokeAuth = nullptr;
-	pRejectAuth = nullptr;
-	lRejectResult = 0;
-	pInvoke = nullptr;
-	pCustom = nullptr;
+}
+
+std::shared_ptr<SnaccInvokeContext> SnaccInvokeContext::Create(const SnaccInvokeContextInit& init)
+{
+	return std::shared_ptr<SnaccInvokeContext>(new SnaccInvokeContext(init));
+}
+
+std::shared_ptr<SnaccInvokeContext> SnaccInvokeContext::Clone() const
+{
+	return std::shared_ptr<SnaccInvokeContext>(new SnaccInvokeContext(*this));
+}
+
+SnaccScopedInvokeMessage::SnaccScopedInvokeMessage(long invokeID, unsigned int uiOperationID, SNACC::AsnType* argument)
+	: m_pInvoke(new SNACC::ROSEInvoke())
+{
+	m_pInvoke->invokeID = invokeID;
+	m_pInvoke->operationID = uiOperationID;
+	m_pInvoke->argument = new AsnAny;
+	m_pInvoke->argument->value = argument;
+}
+
+SnaccScopedInvokeMessage::~SnaccScopedInvokeMessage()
+{
+	if (m_pInvoke && m_pInvoke->argument)
+		m_pInvoke->argument->value = nullptr;
+}
+
+SNACC::ROSEInvoke* SnaccScopedInvokeMessage::GetPtr()
+{
+	return m_pInvoke.get();
+}
+
+const SNACC::ROSEInvoke* SnaccScopedInvokeMessage::GetPtr() const
+{
+	return m_pInvoke.get();
+}
+
+SnaccInvokeContext::SnaccInvokeContext(const SnaccInvokeContextInit& init)
+{
+}
+
+SnaccInvokeContext::SnaccInvokeContext(const SnaccInvokeContext& other)
+	: m_lRejectResult(other.m_lRejectResult),
+	  m_bResponseIsError(other.m_bResponseIsError)
+{
+	if (other.m_pRejectAuth)
+		m_pRejectAuth = static_cast<SNACC::ROSEAuthResult*>(other.m_pRejectAuth->Clone());
 }
 
 SnaccInvokeContext::~SnaccInvokeContext()
 {
-	if (pInvoke)
-		delete pInvoke;
-	if (pInvokeAuth)
-		delete pInvokeAuth;
-	if (pRejectAuth)
-		delete pRejectAuth;
-	if (pCustom)
+	if (m_pRejectAuth)
 	{
-		// If you set data in pCustom ensure that it is deleted (freeed) before the object runs out of scope...
-		ASSERT(0);
+		delete m_pRejectAuth;
+		m_pRejectAuth = nullptr;
 	}
+}
+
+void SnaccInvokeContext::PrepareForTelemetry()
+{
 }
 
 std::string getPrettyPrinted(const SJson::Value& value)
@@ -62,6 +105,42 @@ const char* strstr_limited(const char* haystack, const char* needle, size_t limi
 	}
 
 	return NULL;
+}
+
+SnaccTelemetryData::Reason GetUnhandledReasonFromResult(const long lRoseResult)
+{
+	switch (lRoseResult)
+	{
+		case ROSE_TE_TRANSPORTFAILED:
+			return SnaccTelemetryData::Reason::SEND_FAILED;
+		case ROSE_TE_ENCODE_FAILED:
+			return SnaccTelemetryData::Reason::ENCODE_FAILED;
+		case ROSE_TE_TIMEOUT:
+			return SnaccTelemetryData::Reason::TIMEOUT;
+		case ROSE_TE_SHUTDOWN:
+			return SnaccTelemetryData::Reason::SHUTDOWN;
+		case ROSE_RE_DECODE_FAILED:
+			return SnaccTelemetryData::Reason::DECODE_FAILED;
+		case ROSE_RE_INVALID_ANSWER:
+			return SnaccTelemetryData::Reason::INVALID_RESPONSE;
+		default:
+			return SnaccTelemetryData::Reason::UNKNOWN_FAILURE;
+	}
+}
+
+SnaccTelemetryData::Stage GetOutboundUnhandledStageFromResult(const long lRoseResult)
+{
+	switch (lRoseResult)
+	{
+		case ROSE_TE_TRANSPORTFAILED:
+		case ROSE_TE_ENCODE_FAILED:
+			return SnaccTelemetryData::Stage::OUTBOUND_SEND;
+		case ROSE_TE_TIMEOUT:
+		case ROSE_TE_SHUTDOWN:
+		case ROSE_RE_INVALID_ANSWER:
+		default:
+			return SnaccTelemetryData::Stage::OUTBOUND_WAIT;
+	}
 }
 
 // check if at least one Operation has been registerd
@@ -132,11 +211,14 @@ unsigned int SnaccRoseOperationLookup::LookUpID(const char* szOpName)
 	return 0;
 }
 
-SnaccROSEPendingOperation::SnaccROSEPendingOperation()
+SnaccROSEPendingOperation::SnaccROSEPendingOperation(long lInvokeID, unsigned int uiOperationID, const char* szOperationName)
+	: m_lInvokeID(lInvokeID),
+	  m_uiOperationID(uiOperationID),
+	  m_strOperationName(szOperationName ? szOperationName : ""),
+	  m_pAnswerMessage(nullptr),
+	  m_lRoseResult(0),
+	  m_stResponseData(0)
 {
-	m_pAnswerMessage = 0;
-	m_lInvokeID = 0;
-	m_lRoseResult = 0;
 }
 
 SnaccROSEPendingOperation::~SnaccROSEPendingOperation()
@@ -150,21 +232,63 @@ bool SnaccROSEPendingOperation::WaitForComplete(long ulTimeOut /*= -1*/)
 	return m_CompletedEvent.waitfor(ulTimeOut);
 }
 
-void SnaccROSEPendingOperation::CompleteOperation(long lRoseResult, const SNACC::ROSEMessage* pAnswerMessage)
+void SnaccROSEPendingOperation::CompleteOperation(long lRoseResult, const SNACC::ROSEMessage* pAnswerMessage, size_t stResponseData)
 {
 	m_lRoseResult = lRoseResult;
+	m_stResponseData = stResponseData;
 	if (pAnswerMessage)
 		m_pAnswerMessage = pAnswerMessage;
 	m_CompletedEvent.signal();
 }
 
-SnaccROSEBase::SnaccROSEBase(void)
+void SnaccROSEPendingOperation::FinalizeTelemetry(std::shared_ptr<SnaccInvokeContext> pctx)
+{
+	if (!m_pTelemetry)
+		return;
+
+	if (m_pAnswerMessage)
+	{
+		switch (m_pAnswerMessage->choiceId)
+		{
+			case ROSEMessage::resultCid:
+				m_pTelemetry->finalize(SnaccTelemetryData::Outcome::RESULT, SnaccTelemetryData::Stage::OUTBOUND_WAIT, SnaccTelemetryData::Reason::REMOTE_RESULT, m_lRoseResult, m_stResponseData, pctx);
+				break;
+			case ROSEMessage::errorCid:
+				m_pTelemetry->finalize(SnaccTelemetryData::Outcome::ERR, SnaccTelemetryData::Stage::OUTBOUND_WAIT, SnaccTelemetryData::Reason::REMOTE_ERROR, m_lRoseResult, m_stResponseData, pctx);
+				break;
+			case ROSEMessage::rejectCid:
+				m_pTelemetry->finalize(SnaccTelemetryData::Outcome::REJECT, SnaccTelemetryData::Stage::OUTBOUND_WAIT, SnaccTelemetryData::Reason::REMOTE_REJECT, m_lRoseResult, m_stResponseData, pctx);
+				break;
+			default:
+				m_pTelemetry->finalize(SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::OUTBOUND_WAIT, SnaccTelemetryData::Reason::INVALID_RESPONSE, m_lRoseResult, std::nullopt, pctx);
+				break;
+		}
+		return;
+	}
+
+	if (m_lRoseResult != ROSE_NOERROR)
+	{
+		m_pTelemetry->finalize(SnaccTelemetryData::Outcome::UNHANDLED, GetOutboundUnhandledStageFromResult(m_lRoseResult), GetUnhandledReasonFromResult(m_lRoseResult), m_lRoseResult, std::nullopt, std::move(pctx));
+		return;
+	}
+
+	m_pTelemetry->finalize(SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::OUTBOUND_WAIT, SnaccTelemetryData::Reason::WAIT_SKIPPED, m_lRoseResult, std::nullopt, std::move(pctx));
+}
+
+SnaccROSEBase::SnaccROSEBase(const wchar_t* szClassName)
+	: m_strClassName(szClassName)
 {
 }
 
-SnaccROSEBase::SnaccROSEBase(const std::set<int>& multithreadInvokeIDs)
-	: m_multithreadInvokeIDs(multithreadInvokeIDs)
+SnaccROSEBase::SnaccROSEBase(const wchar_t* szClassName, const std::set<int>& multithreadInvokeIDs)
+	: m_strClassName(szClassName),
+	  m_multithreadInvokeIDs(multithreadInvokeIDs)
 {
+}
+
+void SnaccROSEBase::SetTelemetryCallback(SnaccTelemetryCallback* pTelemetryCallBack)
+{
+	m_pTelemetryCallback = pTelemetryCallBack;
 }
 
 SnaccROSEBase::~SnaccROSEBase(void)
@@ -196,11 +320,14 @@ void SnaccROSEBase::CompleteAllPendingOperations()
 		it->second->CompleteOperation(ROSE_TE_SHUTDOWN, NULL);
 }
 
-void SnaccROSEBase::AddPendingOperation(int invokeID, SnaccROSEPendingOperation* pOperation)
+SnaccROSEPendingOperation& SnaccROSEBase::AddPendingOperation(int invokeID, unsigned int uiOperationID, const char* szOperationName)
 {
 	std::lock_guard<std::mutex> guard(m_InternalProtectMutex);
 
-	m_PendingOperations.insert(SnaccROSEPendingOperationPair(invokeID, pOperation));
+	auto pendingOperation = SnaccROSEPendingOperation::Create(invokeID, uiOperationID, szOperationName);
+	auto result = m_PendingOperations.emplace(invokeID, std::move(pendingOperation));
+	ASSERT(result.second);
+	return *result.first->second;
 }
 
 void SnaccROSEBase::RemovePendingOperation(int invokeID)
@@ -212,7 +339,7 @@ void SnaccROSEBase::RemovePendingOperation(int invokeID)
 		m_PendingOperations.erase(it);
 }
 
-bool SnaccROSEBase::CompletePendingOperation(int invokeID, const SNACC::ROSEMessage* pMessage)
+bool SnaccROSEBase::CompletePendingOperation(int invokeID, const SNACC::ROSEMessage* pMessage, unsigned long ulMessageSize)
 {
 	std::lock_guard<std::mutex> guard(m_InternalProtectMutex);
 
@@ -220,7 +347,23 @@ bool SnaccROSEBase::CompletePendingOperation(int invokeID, const SNACC::ROSEMess
 	if (it != m_PendingOperations.end())
 	{
 		// found...
-		it->second->CompleteOperation(ROSE_NOERROR, pMessage);
+		long lRoseResult = ROSE_RE_INVALID_ANSWER;
+		switch (pMessage->choiceId)
+		{
+			case ROSEMessage::resultCid:
+				lRoseResult = ROSE_NOERROR;
+				break;
+			case ROSEMessage::errorCid:
+				lRoseResult = ROSE_ERROR_VALUE;
+				break;
+			case ROSEMessage::rejectCid:
+				lRoseResult = GetRejectResultCode(pMessage->reject);
+				break;
+			default:
+				break;
+		}
+
+		it->second->CompleteOperation(lRoseResult, pMessage, ulMessageSize);
 		return true;
 	}
 	else
@@ -229,6 +372,72 @@ bool SnaccROSEBase::CompletePendingOperation(int invokeID, const SNACC::ROSEMess
 	}
 
 	return false;
+}
+
+bool SnaccROSEBase::GetPendingOperationTelemetryInfo(int invokeID, unsigned int& uiOperationID, std::string& strOperationName)
+{
+	std::lock_guard<std::mutex> guard(m_InternalProtectMutex);
+
+	const auto it = m_PendingOperations.find(invokeID);
+	if (it == m_PendingOperations.end())
+		return false;
+
+	uiOperationID = it->second->m_uiOperationID;
+	strOperationName = it->second->m_strOperationName;
+	return true;
+}
+
+std::shared_ptr<SnaccInvokeContext> SnaccROSEBase::CreateInvokeContext(const SnaccInvokeContextInit& init)
+{
+	return SnaccInvokeContext::Create(init);
+}
+
+long SnaccROSEBase::GetRejectResultCode(const SNACC::ROSEReject* pReject)
+{
+	long lRoseResult = ROSE_REJECT_UNKNOWN;
+	if (!pReject || !pReject->reject)
+		return lRoseResult;
+
+	if (pReject->reject->choiceId == RejectProblem::invokeProblemCid && pReject->reject->invokeProblem)
+	{
+		if (*pReject->reject->invokeProblem == InvokeProblem::unrecognisedOperation)
+			lRoseResult = ROSE_REJECT_UNKNOWNOPERATION;
+		else if (*pReject->reject->invokeProblem == InvokeProblem::mistypedArgument)
+			lRoseResult = ROSE_REJECT_MISTYPEDARGUMENT;
+		else if (*pReject->reject->invokeProblem == InvokeProblem::resourceLimitation)
+			lRoseResult = ROSE_REJECT_FUNCTIONMISSING;
+		else if (*pReject->reject->invokeProblem == InvokeProblem::authenticationIncomplete)
+			lRoseResult = ROSE_REJECT_AUTHENTICATIONINCOMPLETE;
+		else if (*pReject->reject->invokeProblem == InvokeProblem::authenticationFailed)
+			lRoseResult = ROSE_REJECT_AUTHENTICATIONFAILED;
+	}
+
+	return lRoseResult;
+}
+
+long SnaccROSEBase::GetRejectResultCode(const SNACC::ROSEReject* pReject, SnaccInvokeContext& ctx)
+{
+	long lRoseResult = GetRejectResultCode(pReject);
+	if (!pReject || !pReject->reject)
+		return lRoseResult;
+
+	if (pReject->reject->choiceId == RejectProblem::invokeProblemCid && pReject->reject->invokeProblem)
+	{
+		if (*pReject->reject->invokeProblem == InvokeProblem::authenticationIncomplete)
+		{
+			if (pReject->authentication)
+				ctx.m_pRejectAuth = (SNACC::ROSEAuthResult*)pReject->authentication->Clone();
+			ctx.m_lRejectResult = ROSE_REJECT_AUTHENTICATIONINCOMPLETE;
+		}
+		else if (*pReject->reject->invokeProblem == InvokeProblem::authenticationFailed)
+		{
+			if (pReject->authentication)
+				ctx.m_pRejectAuth = (SNACC::ROSEAuthResult*)pReject->authentication->Clone();
+			ctx.m_lRejectResult = ROSE_REJECT_AUTHENTICATIONFAILED;
+		}
+	}
+
+	return lRoseResult;
 }
 
 bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long lSize, bool bLogTransportData /*= true */)
@@ -262,22 +471,40 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 						std::string strError = getPrettyPrinted(error);
 						PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
 
+						unsigned int uiOperationID = 0;
+						const char* szOperationName = nullptr;
+						auto outcome = SnaccTelemetryData::Outcome::UNHANDLED;
+						long lTelemetryResult = ROSE_RE_DECODE_FAILED;
 						if (pmessage->choiceId == ROSEMessage::invokeCid && pmessage->invoke)
 						{
-							ROSEReject reject;
-							if ((AsnIntType)pmessage->invoke->invokeID)
+							auto* pInvoke = pmessage->invoke;
+							uiOperationID = pInvoke->operationID;
+							szOperationName = SnaccRoseOperationLookup::LookUpName(uiOperationID);
+							if ((AsnIntType)pInvoke->invokeID != 99999)
 							{
-								reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
-								reject.invokedID.invokedID = new AsnInt(pmessage->invoke->invokeID);
-							}
-							else
-							{
-								reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
-								reject.invokedID.invokednull = new AsnNull;
-							}
+								ROSEReject reject;
+								if ((AsnIntType)pInvoke->invokeID)
+								{
+									reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
+									reject.invokedID.invokedID = new AsnInt(pInvoke->invokeID);
+								}
+								else
+								{
+									reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
+									reject.invokedID.invokednull = new AsnNull;
+								}
 
-							SendReject(&reject);
+								const long lRejectResult = SendRejectEx(&reject);
+								if (lRejectResult == ROSE_NOERROR)
+								{
+									outcome = SnaccTelemetryData::Outcome::REJECT;
+									lTelemetryResult = ROSE_REJECT_MISTYPEDARGUMENT;
+								}
+								else
+									lTelemetryResult = lRejectResult;
+							}
 						}
+						OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, szOperationName, lSize, outcome, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, lTelemetryResult));
 						delete pmessage;
 						return true;
 					}
@@ -317,26 +544,45 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 							std::string strError = getPrettyPrinted(error);
 							PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
 
+							unsigned int uiOperationID = 0;
+							const char* szOperationName = nullptr;
+							auto outcome = SnaccTelemetryData::Outcome::UNHANDLED;
+							long lTelemetryResult = ROSE_RE_DECODE_FAILED;
 							if (pmessage->choiceId == ROSEMessage::invokeCid && pmessage->invoke)
 							{
-								ROSEReject reject;
-								if ((AsnIntType)pmessage->invoke->invokeID)
+								auto* pInvoke = pmessage->invoke;
+								uiOperationID = pInvoke->operationID;
+								szOperationName = SnaccRoseOperationLookup::LookUpName(uiOperationID);
+								if ((AsnIntType)pInvoke->invokeID != 99999)
 								{
-									reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
-									reject.invokedID.invokedID = new AsnInt(pmessage->invoke->invokeID);
+									ROSEReject reject;
+									if ((AsnIntType)pInvoke->invokeID)
+									{
+										reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
+										reject.invokedID.invokedID = new AsnInt(pInvoke->invokeID);
+									}
+									else
+									{
+										reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
+										reject.invokedID.invokednull = new AsnNull;
+									}
+									reject.reject = new RejectProblem;
+									reject.reject->choiceId = RejectProblem::invokeProblemCid;
+									reject.reject->invokeProblem = new InvokeProblem;
+									*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
+									reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
+
+									const long lRejectResult = SendRejectEx(&reject);
+									if (lRejectResult == ROSE_NOERROR)
+									{
+										outcome = SnaccTelemetryData::Outcome::REJECT;
+										lTelemetryResult = ROSE_REJECT_MISTYPEDARGUMENT;
+									}
+									else
+										lTelemetryResult = lRejectResult;
 								}
-								else
-								{
-									reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
-									reject.invokedID.invokednull = new AsnNull;
-								}
-								reject.reject = new RejectProblem;
-								reject.reject->choiceId = RejectProblem::invokeProblemCid;
-								reject.reject->invokeProblem = new InvokeProblem;
-								*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
-								reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
-								SendReject(&reject);
 							}
+							OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, szOperationName, lSize, outcome, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, lTelemetryResult));
 							delete pmessage;
 							return true;
 						}
@@ -356,12 +602,12 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 						std::string strPayLoad;
 						strPayLoad.assign(lpBytes, lSize);
 #endif
-
 						SJson::Value error;
 						error["exception"] = reader.getFormattedErrorMessages();
 						error["where"] = __FUNCTION__;
 						std::string strError = getPrettyPrinted(error);
 						PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+						OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, lSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
 					}
 					break;
 				}
@@ -378,6 +624,25 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 		error["error"] = (int)ex.m_errorCode;
 		std::string strError = getPrettyPrinted(error);
 		PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+		OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, lSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
+	}
+	catch (const std::exception& ex)
+	{
+		SJson::Value error;
+		error["exception"] = ex.what();
+		error["method"] = __FUNCTION__;
+		std::string strError = getPrettyPrinted(error);
+		PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+		OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, lSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
+	}
+	catch (...)
+	{
+		SJson::Value error;
+		error["exception"] = "...";
+		error["method"] = __FUNCTION__;
+		std::string strError = getPrettyPrinted(error);
+		PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+		OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, lSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
 	}
 	return bReturn;
 }
@@ -436,169 +701,229 @@ std::string SnaccROSEBase::GetEncoded(const SNACC::TransportEncoding encoding, A
 	return strData;
 }
 
-void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long lSize, bool bLogTransportData /*= true*/)
+SNACC::TransportEncoding SnaccROSEBase::DetectEncoding(const char* lpBytes, unsigned long ulSize) const
 {
-	if (!lSize)
+	if (!ulSize)
+		return SNACC::TransportEncoding::UNKNOWN;
+
+	unsigned char byFirst = (unsigned char)*lpBytes;
+	if (byFirst == 0xA1 || byFirst == 0xA2 || byFirst == 0xA3 || byFirst == 0xA4)
+		return SNACC::TransportEncoding::BER;
+	else if (byFirst == 'J')
+		return SNACC::TransportEncoding::JSON;
+	else if (byFirst == 'J' || byFirst == '{' || byFirst == '[')
+		return SNACC::TransportEncoding::JSON_NO_HEADING;
+	else
+	{
+		ASSERT(false);
+		return SNACC::TransportEncoding::UNKNOWN;
+	}
+}
+
+void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long ulSize, bool bLogTransportData /*= true*/)
+{
+	if (!ulSize)
 		return;
+
+	if (m_eTransportEncoding == SNACC::TransportEncoding::UNKNOWN)
+		m_eTransportEncoding = DetectEncoding(lpBytes, ulSize);
 
 	try
 	{
-		unsigned char byFirst = (unsigned char)*lpBytes;
-
-		if (byFirst == 0xA1 || byFirst == 0xA2 || byFirst == 0xA3 || byFirst == 0xA4)
+		switch (m_eTransportEncoding)
 		{
-			m_eTransportEncoding = SNACC::TransportEncoding::BER;
-			AsnBuf buffer((const char*)lpBytes, lSize);
-			ROSEMessage* pmessage = new ROSEMessage;
-			AsnLen bytesDecoded = 0;
-			try
-			{
-				pmessage->BDec(buffer, bytesDecoded);
-			}
-			catch (const SnaccException& ex)
-			{
-				if (bLogTransportData)
-					bLogTransportData = LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, lSize, nullptr, nullptr);
-
-				SJson::Value error;
-				error["exception"] = ex.what();
-				error["method"] = __FUNCTION__;
-				error["error"] = (int)ex.m_errorCode;
-				std::string strError = getPrettyPrinted(error);
-				PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
-
-				OnRoseDecodeError(bLogTransportData, SNACC::TransportEncoding::BER, lpBytes, lSize, ex.what());
-
-				if (pmessage->choiceId == ROSEMessage::invokeCid && pmessage->invoke)
+			case SNACC::TransportEncoding::BER:
 				{
-					// Provide the detail that the argument was non decodable to the client
-					ROSEReject reject;
-					reject.reject = new RejectProblem();
-					reject.reject->choiceId = RejectProblem::invokeProblemCid;
-					reject.reject->invokeProblem = new InvokeProblem(SNACC::InvokeProblem::mistypedArgument);
-					reject.details = new UTF8String();
-					reject.details->setASCII(ex.what());
-					if ((AsnIntType)pmessage->invoke->invokeID)
+					AsnBuf buffer((const char*)lpBytes, ulSize);
+					ROSEMessage* pmessage = new ROSEMessage;
+					AsnLen bytesDecoded = 0;
+					try
 					{
-						reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
-						reject.invokedID.invokedID = new AsnInt(pmessage->invoke->invokeID);
+						pmessage->BDec(buffer, bytesDecoded);
+						if (bLogTransportData)
+							LogTransportData(false, SNACC::TransportEncoding::BER, nullptr, lpBytes, ulSize, nullptr, nullptr);
+
+						// pmessage will be deleted inside
+						OnROSEMessage(pmessage, true, ulSize);
+					}
+					catch (const SnaccException& ex)
+					{
+						if (bLogTransportData)
+							bLogTransportData = LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, ulSize, nullptr, nullptr);
+
+						SJson::Value error;
+						error["exception"] = ex.what();
+						error["method"] = __FUNCTION__;
+						error["error"] = (int)ex.m_errorCode;
+						std::string strError = getPrettyPrinted(error);
+						PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+
+						OnRoseDecodeError(bLogTransportData, SNACC::TransportEncoding::BER, lpBytes, ulSize, ex.what());
+
+						unsigned int uiOperationID = 0;
+						const char* szOperationName = nullptr;
+						auto outcome = SnaccTelemetryData::Outcome::UNHANDLED;
+						long lTelemetryResult = ROSE_RE_DECODE_FAILED;
+						if (pmessage->choiceId == ROSEMessage::invokeCid && pmessage->invoke)
+						{
+							auto* pInvoke = pmessage->invoke;
+							uiOperationID = pInvoke->operationID;
+							szOperationName = SnaccRoseOperationLookup::LookUpName(uiOperationID);
+							if ((AsnIntType)pInvoke->invokeID != 99999)
+							{
+								// Provide the detail that the argument was non decodable to the client
+								ROSEReject reject;
+								reject.reject = new RejectProblem();
+								reject.reject->choiceId = RejectProblem::invokeProblemCid;
+								reject.reject->invokeProblem = new InvokeProblem(SNACC::InvokeProblem::mistypedArgument);
+								reject.details = new UTF8String();
+								reject.details->setASCII(ex.what());
+								if ((AsnIntType)pInvoke->invokeID)
+								{
+									reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
+									reject.invokedID.invokedID = new AsnInt(pInvoke->invokeID);
+								}
+								else
+								{
+									reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
+									reject.invokedID.invokednull = new AsnNull;
+								}
+
+								const long lRejectResult = SendRejectEx(&reject);
+								if (lRejectResult == ROSE_NOERROR)
+								{
+									outcome = SnaccTelemetryData::Outcome::REJECT;
+									lTelemetryResult = ROSE_REJECT_MISTYPEDARGUMENT;
+								}
+								else
+									lTelemetryResult = lRejectResult;
+							}
+						}
+						OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, szOperationName, ulSize, outcome, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, lTelemetryResult));
+						delete pmessage;
+					}
+					break;
+				}
+			case SNACC::TransportEncoding::JSON:
+			case SNACC::TransportEncoding::JSON_NO_HEADING:
+				{
+					int iHeaderLen = GetJsonHeaderLen(lpBytes, ulSize);
+
+					SJson::Value value;
+					SJson::Reader reader;
+					if (reader.parse((const char*)lpBytes + iHeaderLen, (const char*)lpBytes + ulSize, value))
+					{
+						ROSEMessage* pmessage = new ROSEMessage;
+						try
+						{
+							if (!pmessage->JDec(value))
+								throw InvalidTagException("ROSEMessage", "decode failed: ROSEMessage", STACK_ENTRY);
+							if (bLogTransportData)
+								LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, ulSize, pmessage, &value);
+							// pmessage will be deleted inside
+							OnROSEMessage(pmessage, true, ulSize);
+						}
+						catch (const SnaccException& ex)
+						{
+							if (bLogTransportData)
+								bLogTransportData = LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, ulSize, nullptr, nullptr);
+
+							SJson::Value error;
+							error["exception"] = ex.what();
+							error["method"] = __FUNCTION__;
+							error["error"] = (int)ex.m_errorCode;
+							std::string strError = getPrettyPrinted(error);
+							PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+
+							OnRoseDecodeError(bLogTransportData, m_eTransportEncoding, lpBytes, ulSize, ex.what());
+
+							unsigned int uiOperationID = 0;
+							const char* szOperationName = nullptr;
+							auto outcome = SnaccTelemetryData::Outcome::UNHANDLED;
+							long lTelemetryResult = ROSE_RE_DECODE_FAILED;
+							if (pmessage->choiceId == ROSEMessage::invokeCid && pmessage->invoke)
+							{
+								auto* pInvoke = pmessage->invoke;
+								uiOperationID = pInvoke->operationID;
+								szOperationName = SnaccRoseOperationLookup::LookUpName(uiOperationID);
+								if ((AsnIntType)pInvoke->invokeID != 99999)
+								{
+									ROSEReject reject;
+									if ((AsnIntType)pInvoke->invokeID)
+									{
+										reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
+										reject.invokedID.invokedID = new AsnInt(pInvoke->invokeID);
+									}
+									else
+									{
+										reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
+										reject.invokedID.invokednull = new AsnNull;
+									}
+									reject.reject = new RejectProblem;
+									reject.reject->choiceId = RejectProblem::invokeProblemCid;
+									reject.reject->invokeProblem = new InvokeProblem;
+									*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
+									reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
+
+									const long lRejectResult = SendRejectEx(&reject);
+									if (lRejectResult == ROSE_NOERROR)
+									{
+										outcome = SnaccTelemetryData::Outcome::REJECT;
+										lTelemetryResult = ROSE_REJECT_MISTYPEDARGUMENT;
+									}
+									else
+										lTelemetryResult = lRejectResult;
+								}
+							}
+							OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, szOperationName, ulSize, outcome, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, lTelemetryResult));
+							delete pmessage;
+						}
 					}
 					else
 					{
+						if (bLogTransportData)
+							bLogTransportData = LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, ulSize, nullptr, nullptr);
+
+						SJson::Value error;
+						error["exception"] = reader.getFormattedErrorMessages();
+						error["method"] = __FUNCTION__;
+						std::string strError = getPrettyPrinted(error);
+						PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+
+						OnRoseDecodeError(bLogTransportData, m_eTransportEncoding, lpBytes, ulSize, reader.getFormattedErrorMessages());
+
+						ROSEReject reject;
 						reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
 						reject.invokedID.invokednull = new AsnNull;
-					}
-					SendReject(&reject);
-				}
-				delete pmessage;
-				return;
-			}
 
-			if (bLogTransportData)
-				LogTransportData(false, SNACC::TransportEncoding::BER, nullptr, lpBytes, lSize, nullptr, nullptr);
-
-			// pmessage will be deleted inside
-			OnROSEMessage(pmessage, true, lSize);
-		}
-		else if (byFirst == 'J' || byFirst == '{' || byFirst == '[')
-		{
-			int iHeaderLen = 0;
-			if (byFirst == 'J')
-			{
-				m_eTransportEncoding = SNACC::TransportEncoding::JSON;
-				iHeaderLen = GetJsonHeaderLen(lpBytes, lSize);
-				lpBytes += iHeaderLen;
-				lSize -= iHeaderLen;
-			}
-			else
-				m_eTransportEncoding = SNACC::TransportEncoding::JSON_NO_HEADING;
-
-			SJson::Value value;
-			SJson::Reader reader;
-			if (reader.parse((const char*)lpBytes, (const char*)lpBytes + lSize, value))
-			{
-				ROSEMessage* pmessage = new ROSEMessage;
-				try
-				{
-					if (!pmessage->JDec(value))
-						throw InvalidTagException("ROSEMessage", "decode failed: ROSEMessage", STACK_ENTRY);
-				}
-				catch (const SnaccException& ex)
-				{
-					if (bLogTransportData)
-						bLogTransportData = LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, lSize, nullptr, nullptr);
-
-					SJson::Value error;
-					error["exception"] = ex.what();
-					error["method"] = __FUNCTION__;
-					error["error"] = (int)ex.m_errorCode;
-					std::string strError = getPrettyPrinted(error);
-					PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
-
-					OnRoseDecodeError(bLogTransportData, m_eTransportEncoding, lpBytes, lSize, ex.what());
-
-					if (pmessage->choiceId == ROSEMessage::invokeCid && pmessage->invoke)
-					{
-						ROSEReject reject;
-						if ((AsnIntType)pmessage->invoke->invokeID)
-						{
-							reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
-							reject.invokedID.invokedID = new AsnInt(pmessage->invoke->invokeID);
-						}
-						else
-						{
-							reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
-							reject.invokedID.invokednull = new AsnNull;
-						}
 						reject.reject = new RejectProblem;
 						reject.reject->choiceId = RejectProblem::invokeProblemCid;
 						reject.reject->invokeProblem = new InvokeProblem;
 						*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
 						reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
-						SendReject(&reject);
+						auto outcome = SnaccTelemetryData::Outcome::UNHANDLED;
+						long lTelemetryResult = ROSE_RE_DECODE_FAILED;
+						const long lRejectResult = SendRejectEx(&reject);
+						if (lRejectResult == ROSE_NOERROR)
+						{
+							outcome = SnaccTelemetryData::Outcome::REJECT;
+							lTelemetryResult = ROSE_REJECT_MISTYPEDARGUMENT;
+						}
+						else
+							lTelemetryResult = lRejectResult;
+						OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, ulSize, outcome, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, lTelemetryResult));
 					}
-					delete pmessage;
-					return;
+					break;
 				}
-
-				if (bLogTransportData)
-					LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, lSize, pmessage, &value);
-
-				// pmessage will be deleted inside
-				OnROSEMessage(pmessage, true, lSize);
-			}
-			else
-			{
-				if (bLogTransportData)
-					bLogTransportData = LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, lSize, nullptr, nullptr);
-
-				SJson::Value error;
-				error["exception"] = reader.getFormattedErrorMessages();
-				error["method"] = __FUNCTION__;
-				std::string strError = getPrettyPrinted(error);
-				PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
-
-				OnRoseDecodeError(bLogTransportData, m_eTransportEncoding, lpBytes, lSize, reader.getFormattedErrorMessages());
-
-				ROSEReject reject;
-				reject.invokedID.choiceId = ROSERejectChoice::invokednullCid;
-				reject.invokedID.invokednull = new AsnNull;
-
-				reject.reject = new RejectProblem;
-				reject.reject->choiceId = RejectProblem::invokeProblemCid;
-				reject.reject->invokeProblem = new InvokeProblem;
-				*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
-				reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
-				SendReject(&reject);
-				return;
-			}
-		}
-		else
-		{
-			// if we don´t know the encoding, we need to log it binary to ensure proper readability in the logs (ensure payload is hex converted)
-			if (bLogTransportData)
-				bLogTransportData = LogTransportData(false, SNACC::TransportEncoding::BER, nullptr, lpBytes, lSize, nullptr, nullptr);
-			OnRoseDecodeError(bLogTransportData, SNACC::TransportEncoding::BER, lpBytes, lSize, "unknown encoding");
+			default:
+				{
+					// if we don't know the encoding, we need to log it binary to ensure proper readability in the logs (ensure payload is hex converted)
+					if (bLogTransportData)
+						bLogTransportData = LogTransportData(false, SNACC::TransportEncoding::BER, nullptr, lpBytes, ulSize, nullptr, nullptr);
+					OnRoseDecodeError(bLogTransportData, SNACC::TransportEncoding::BER, lpBytes, ulSize, "unknown encoding");
+					OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, ulSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
+					break;
+				}
 		}
 	}
 	catch (const SnaccException& ex)
@@ -609,6 +934,7 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long lSize, 
 		error["error"] = (int)ex.m_errorCode;
 		std::string strError = getPrettyPrinted(error);
 		PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+		OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, ulSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
 	}
 	catch (const std::exception& ex)
 	{
@@ -617,6 +943,7 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long lSize, 
 		error["method"] = __FUNCTION__;
 		std::string strError = getPrettyPrinted(error);
 		PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+		OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, ulSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
 	}
 	catch (...)
 	{
@@ -625,10 +952,11 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long lSize, 
 		error["method"] = __FUNCTION__;
 		std::string strError = getPrettyPrinted(error);
 		PrintJSONToLog(false, true, nullptr, strError.c_str(), strError.length());
+		OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, 0, nullptr, ulSize, SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::INBOUND_DECODE, SnaccTelemetryData::Reason::DECODE_FAILED, ROSE_RE_DECODE_FAILED));
 	}
 }
 
-bool SnaccROSEBase::OnROSEMessage(const SNACC::ROSEMessage* pMessage, bool bAllowAllInvokes, unsigned long ulMessageSize)
+bool SnaccROSEBase::OnROSEMessage(SNACC::ROSEMessage* pMessage, bool bAllowAllInvokes, unsigned long ulMessageSize)
 {
 	bool bProcessed = false;
 	switch (pMessage->choiceId)
@@ -643,7 +971,7 @@ bool SnaccROSEBase::OnROSEMessage(const SNACC::ROSEMessage* pMessage, bool bAllo
 						pInvoke->operationID = SnaccRoseOperationLookup::LookUpID(pInvoke->operationName->getASCII().c_str());
 
 					if (pInvoke->operationID || pInvoke->operationName)
-						OnInvokeMessage(pMessage);
+						OnInvokeMessage(pMessage, ulMessageSize);
 
 					bProcessed = true;
 				}
@@ -652,31 +980,31 @@ bool SnaccROSEBase::OnROSEMessage(const SNACC::ROSEMessage* pMessage, bool bAllo
 		case ROSEMessage::resultCid:
 			if (pMessage->result)
 			{
-				OnResultMessage(pMessage->result);
+				OnResultMessage(pMessage->result, ulMessageSize);
 				// do not intercept anything if pmessage->result->result == nullptr is in place, because the missing invokeID already takes this into account
-				CompletePendingOperation(pMessage->result->invokeID, pMessage);
+				CompletePendingOperation(pMessage->result->invokeID, pMessage, ulMessageSize);
 				return true;
 			}
 			break;
 		case ROSEMessage::errorCid:
 			if (pMessage->error)
 			{
-				OnErrorMessage(pMessage->error);
+				OnErrorMessage(pMessage->error, ulMessageSize);
 				// do not intercept anything if pmessage->error->error == nullptr is in place, because the missing invokeID already takes this into account
-				CompletePendingOperation(pMessage->error->invokedID, pMessage);
+				CompletePendingOperation(pMessage->error->invokedID, pMessage, ulMessageSize);
 				return true;
 			}
 			break;
 		case ROSEMessage::rejectCid:
 			if (pMessage->reject)
 			{
-				OnRejectMessage(pMessage->reject);
+				OnRejectMessage(pMessage->reject, ulMessageSize);
 				if (pMessage->reject->invokedID.choiceId == ROSERejectChoice::invokedIDCid)
 				{
 					// Test! with REJECT the InvokeID is a choice and therefore the ID itself is a pointer! and it can become nullptr.
 					if (pMessage->reject->invokedID.invokedID != nullptr)
 					{
-						CompletePendingOperation(*pMessage->reject->invokedID.invokedID, pMessage);
+						CompletePendingOperation(*pMessage->reject->invokedID.invokedID, pMessage, ulMessageSize);
 						return true;
 					}
 				}
@@ -690,7 +1018,7 @@ bool SnaccROSEBase::OnROSEMessage(const SNACC::ROSEMessage* pMessage, bool bAllo
 	return bProcessed;
 }
 
-long SnaccROSEBase::SendReject(SNACC::ROSEReject* preject)
+long SnaccROSEBase::EncodeReject(SNACC::ROSEReject* preject, std::string& strResponse)
 {
 	long lRoseResult = ROSE_NOERROR;
 
@@ -704,13 +1032,10 @@ long SnaccROSEBase::SendReject(SNACC::ROSEReject* preject)
 		AsnBuf OutBuf;
 		AsnLen BytesEncoded = rejectMsg.BEnc(OutBuf);
 
-		std::string strData;
 		OutBuf.ResetMode();
-		OutBuf.GetSeg(strData, BytesEncoded);
+		OutBuf.GetSeg(strResponse, BytesEncoded);
 
-		LogTransportData(true, m_eTransportEncoding, nullptr, strData.c_str(), strData.length(), &rejectMsg, nullptr);
-
-		lRoseResult = SendBinaryDataBlockEx(strData.c_str(), BytesEncoded, nullptr);
+		LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), strResponse.length(), &rejectMsg, nullptr);
 	}
 	else if (m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING)
 	{
@@ -734,7 +1059,6 @@ long SnaccROSEBase::SendReject(SNACC::ROSEReject* preject)
 			LogTransportData(true, m_eTransportEncoding, nullptr, strData.c_str(), strData.length(), &rejectMsg, nullptr);
 			if (!strPrefix.empty())
 				strData.insert(0, strPrefix);
-			lRoseResult = SendBinaryDataBlockEx(strData.c_str(), (unsigned long)strData.length(), nullptr);
 		}
 	}
 	else
@@ -746,6 +1070,18 @@ long SnaccROSEBase::SendReject(SNACC::ROSEReject* preject)
 	rejectMsg.reject = 0;
 
 	return lRoseResult;
+}
+
+long SnaccROSEBase::SendRejectEx(SNACC::ROSEReject* preject)
+{
+	std::string strResponse;
+	auto lResult = EncodeReject(preject, strResponse);
+	if (lResult)
+		return lResult;
+
+	auto ctx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND, nullptr));
+
+	return SendBinaryDataBlockEx(strResponse.c_str(), strResponse.length(), *ctx);
 }
 
 long SnaccROSEBase::GetJsonLengthPrefix(std::string_view strJson, std::string& strLenghtPrefix) const
@@ -771,9 +1107,9 @@ long SnaccROSEBase::GetJsonLengthPrefix(std::string_view strJson, std::string& s
 	return ROSE_NOERROR;
 }
 
-long SnaccROSEBase::SendRejectInvoke(int invokeID, SNACC::InvokeProblem problem, const char* szError /*=NULL*/, const wchar_t* szSessionID /*= 0*/, SNACC::ROSEAuthResult* pAuthHeader /*=0*/)
+long SnaccROSEBase::EncodeRejectInvoke(unsigned int uiInvokeID, SNACC::InvokeProblem problem, std::string& strResponse, const char* szError /*= nullptr*/, const wchar_t* szSessionID /*= nullptr*/, SNACC::ROSEAuthResult* pAuthHeader /*=0*/)
 {
-	if (invokeID == 99999)
+	if (uiInvokeID == 99999)
 	{
 		// Events do not get an answer
 		return 0;
@@ -781,7 +1117,7 @@ long SnaccROSEBase::SendRejectInvoke(int invokeID, SNACC::InvokeProblem problem,
 	ROSEReject reject;
 	reject.invokedID.choiceId = ROSERejectChoice::invokedIDCid;
 	reject.invokedID.invokedID = new AsnInt;
-	*reject.invokedID.invokedID = invokeID;
+	*reject.invokedID.invokedID = uiInvokeID;
 	if (szSessionID)
 		reject.sessionID = new UTF8String(szSessionID);
 	reject.reject = new RejectProblem;
@@ -792,32 +1128,73 @@ long SnaccROSEBase::SendRejectInvoke(int invokeID, SNACC::InvokeProblem problem,
 	if (pAuthHeader)
 		reject.authentication = (SNACC::ROSEAuthResult*)pAuthHeader->Clone();
 
-	if ((m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING) && szError != NULL)
+	if ((m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING) && szError)
 		reject.details = UTF8String::CreateNewFromUTF8(szError);
-	return SendReject(&reject);
+
+	return EncodeReject(&reject, strResponse);
 }
 
-void SnaccROSEBase::OnInvokeMessage(const SNACC::ROSEMessage* pMessage)
+long SnaccROSEBase::EncodeInvokeRejectResponse(const SNACC::ROSEInvoke* pInvoke, long lProtocolResult, SnaccInvokeContext& ctx, std::string& strResponse)
 {
-	auto start = std::chrono::steady_clock::now();
-	long lRoseResult = ROSE_REJECT_UNKNOWNOPERATION;
+	const wchar_t* szSessionID = pInvoke->sessionID ? pInvoke->sessionID->c_str() : nullptr;
+	long lEncodeResult = ROSE_NOERROR;
 
-	SnaccInvokeContext invokeContext;
-	invokeContext.pInvokeAuth = pMessage->invoke->authentication;
-	invokeContext.pInvoke = pMessage->invoke;
+	if (lProtocolResult == ROSE_REJECT_UNKNOWNOPERATION)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::unrecognisedOperation, strResponse, "unrecognisedOperation", szSessionID);
+	else if (lProtocolResult == ROSE_REJECT_MISTYPEDARGUMENT)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::mistypedArgument, strResponse, "mistypedArgument", szSessionID);
+	else if (lProtocolResult == ROSE_REJECT_FUNCTIONMISSING)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::resourceLimitation, strResponse, "functionMissing", szSessionID);
+	else if (lProtocolResult == ROSE_REJECT_INVALIDSESSIONID)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::invalidSessionID, strResponse, "invalidSessionID", szSessionID);
+	else if (lProtocolResult == ROSE_REJECT_AUTHENTICATIONFAILED)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, strResponse, "authenticationFailed", szSessionID, ctx.m_pRejectAuth);
+	else if (lProtocolResult == ROSE_REJECT_AUTHENTICATIONINCOMPLETE)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationIncomplete, strResponse, "authenticationIncomplete", szSessionID, ctx.m_pRejectAuth);
+	else if (lProtocolResult == ROSE_REJECT_AUTHENTICATION_USER_TEMPORARY_LOCKED_OUT)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, strResponse, "temporaryLockedOut", szSessionID, ctx.m_pRejectAuth);
+	else if (lProtocolResult == ROSE_REJECT_AUTHENTICATION_USER_LOCKED_OUT)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, strResponse, "lockedOut", szSessionID, ctx.m_pRejectAuth);
+	else if (lProtocolResult == ROSE_REJECT_AUTHENTICATION_SERVER_BUSY)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, strResponse, "serverBusy", szSessionID, ctx.m_pRejectAuth);
+	else if (lProtocolResult == ROSE_REJECT_ARGUMENT_MISSING)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::mistypedArgument, strResponse, "argumentMissing", szSessionID);
+	else if (lProtocolResult == ROSE_TE_ENCODE_FAILED)
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::resourceLimitation, strResponse, "responseIsTooBig", szSessionID);
+	else
+	{
+		std::stringstream ss;
+		ss << "otherError: 0x" << std::hex << lProtocolResult;
+		const std::string strOtherError = ss.str();
+		lEncodeResult = EncodeRejectInvoke(pInvoke->invokeID, InvokeProblem::unrecognisedOperation, strResponse, strOtherError.c_str(), szSessionID);
+	}
 
-	bool bNotifyRunningOutOfScope = OnInvokeContextCreated(&invokeContext);
+	return lEncodeResult == ROSE_NOERROR ? lProtocolResult : lEncodeResult;
+}
+
+void SnaccROSEBase::OnInvokeMessage(SNACC::ROSEMessage* pMessage, unsigned long ulMessageSize)
+{
+	std::string strResponse;
+	long lResult = ROSE_REJECT_UNKNOWNOPERATION;
 	auto* pInvoke = pMessage->invoke;
+	const char* szOperationName = SnaccRoseOperationLookup::LookUpName(pInvoke->operationID);
+
+	SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName);
+	auto pCtx = SnaccInvokeContext::Create(init);
+	auto telemetry = SnaccTelemetryData::Create(SnaccTelemetryData::Direction::INBOUND, pInvoke->operationID, szOperationName, ulMessageSize);
+	auto telemetryResult = SnaccTelemetryData::Outcome::UNHANDLED;
+	auto telemetryReason = SnaccTelemetryData::Reason::UNKNOWN_FAILURE;
+	bool bInvokeException = false;
 
 	try
 	{
-		lRoseResult = OnInvoke(pMessage, &invokeContext);
+		lResult = OnInvoke(pMessage, *pCtx, strResponse);
 	}
 	catch (const SnaccException& ex)
 	{
 		// decode of invoke detail failed.
-		lRoseResult = ROSE_REJECT_MISTYPEDARGUMENT;
-
+		lResult = ROSE_REJECT_MISTYPEDARGUMENT;
+		bInvokeException = true;
 		SJson::Value error;
 		error["exception"] = ex.what();
 		error["method"] = __FUNCTION__;
@@ -827,61 +1204,86 @@ void SnaccROSEBase::OnInvokeMessage(const SNACC::ROSEMessage* pMessage)
 		PrintJSONToLog(false, true, nullptr, jsonString.c_str(), jsonString.length());
 	}
 
-	// if the Result is ROSE_NOERROR, then the Result has been sent.
+	const bool bIsInvoke = (AsnIntType)pInvoke->invokeID != 99999;
+	const bool bIsRejectResponse = lResult != ROSE_NOERROR && bIsInvoke;
+
+	// if the Result is ROSE_NOERROR the request has been processed with a result or an error (the invoke context points out if it was replied with an error)
 	// if the result is ROSE_REJECT_ASYNCOPERATION, the result will be sent async
-	if (lRoseResult != ROSE_NOERROR && lRoseResult != ROSE_REJECT_ASYNCOPERATION)
+	if (bIsRejectResponse)
 	{
-		// Send reject
-		if (lRoseResult == ROSE_REJECT_UNKNOWNOPERATION)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::unrecognisedOperation, "unrecognisedOperation", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
-		else if (lRoseResult == ROSE_REJECT_MISTYPEDARGUMENT)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::mistypedArgument, "mistypedArgument", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
-		else if (lRoseResult == ROSE_REJECT_FUNCTIONMISSING)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::resourceLimitation, "functionMissing", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
-		else if (lRoseResult == ROSE_REJECT_INVALIDSESSIONID)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::invalidSessionID, "invalidSessionID", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
-		else if (lRoseResult == ROSE_REJECT_AUTHENTICATIONFAILED)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, "authenticationFailed", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0, invokeContext.pRejectAuth);
-		else if (lRoseResult == ROSE_REJECT_AUTHENTICATIONINCOMPLETE)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationIncomplete, "authenticationIncomplete", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0, invokeContext.pRejectAuth);
-		else if (lRoseResult == ROSE_REJECT_AUTHENTICATION_USER_TEMPORARY_LOCKED_OUT)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, "temporaryLockedOut", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0, invokeContext.pRejectAuth);
-		else if (lRoseResult == ROSE_REJECT_AUTHENTICATION_USER_LOCKED_OUT)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, "lockedOut", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0, invokeContext.pRejectAuth);
-		else if (lRoseResult == ROSE_REJECT_AUTHENTICATION_SERVER_BUSY)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::authenticationFailed, "serverBusy", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0, invokeContext.pRejectAuth);
-		else if (lRoseResult == ROSE_REJECT_ARGUMENT_MISSING)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::mistypedArgument, "argumentMissing", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
-		else if (lRoseResult == ROSE_TE_ENCODE_FAILED)
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::resourceLimitation, "responseIsTooBig", pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
-		else
+		lResult = EncodeInvokeRejectResponse(pInvoke, lResult, *pCtx, strResponse);
+		if (lResult != ROSE_NOERROR)
+			telemetryReason = GetUnhandledReasonFromResult(lResult);
+	}
+
+	if (!strResponse.empty())
+	{
+		const long lSendResult = SendBinaryDataBlockEx(strResponse.c_str(), strResponse.length(), *pCtx);
+		if (lSendResult != ROSE_NOERROR)
 		{
-			std::stringstream ss;
-			ss << "otherError: 0x" << std::hex << lRoseResult;
-			SendRejectInvoke(pInvoke->invokeID, InvokeProblem::unrecognisedOperation, ss.str().c_str(), pInvoke->sessionID ? pInvoke->sessionID->c_str() : 0);
+			lResult = lSendResult;
+			telemetryReason = GetUnhandledReasonFromResult(lSendResult);
 		}
 	}
-	if (invokeContext.funcAfterResult)
-		invokeContext.funcAfterResult();
 
-	if (bNotifyRunningOutOfScope)
-		OnInvokeContextRunsOutOfScope(&invokeContext);
+	if (lResult == 0)
+	{
+		// No error while processing
+		if (bIsRejectResponse)
+		{
+			telemetryResult = SnaccTelemetryData::Outcome::REJECT;
+			telemetryReason = bInvokeException ? SnaccTelemetryData::Reason::INVOKE_EXCEPTION : SnaccTelemetryData::Reason::LOCAL_REJECT;
+		}
+		else if (bIsInvoke)
+		{
+			// It is an invoke so we need to check if we have a result or an error as answer
+			if (pCtx->m_bResponseIsError)
+			{
+				telemetryResult = SnaccTelemetryData::Outcome::ERR;
+				telemetryReason = SnaccTelemetryData::Reason::LOCAL_ERROR;
+			}
+			else
+			{
+				telemetryResult = SnaccTelemetryData::Outcome::RESULT;
+				telemetryReason = SnaccTelemetryData::Reason::LOCAL_RESULT;
+			}
+		}
+		else
+		{
+			telemetryResult = SnaccTelemetryData::Outcome::EVENT;
+			telemetryReason = SnaccTelemetryData::Reason::LOCAL_EVENT;
+		}
+	}
+	else if (telemetryReason == SnaccTelemetryData::Reason::UNKNOWN_FAILURE)
+		telemetryReason = GetUnhandledReasonFromResult(lResult);
 
-	// prevent autodelete
-	invokeContext.pInvokeAuth = nullptr;
-	invokeContext.pInvoke = nullptr;
+	telemetry->finalize(telemetryResult, SnaccTelemetryData::Stage::INBOUND_INVOKE, telemetryReason, lResult, strResponse.empty() ? std::nullopt : std::optional(strResponse.length()), std::move(pCtx));
+	OnInvokeProcessed(telemetry);
 }
 
-void SnaccROSEBase::OnResultMessage(const SNACC::ROSEResult* presult)
+void SnaccROSEBase::OnResultMessage(SNACC::ROSEResult* presult, unsigned long ulMessageSize)
 {
+	unsigned int uiOperationID = 0;
+	std::string strOperationName;
+	GetPendingOperationTelemetryInfo(presult->invokeID, uiOperationID, strOperationName);
+	OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, strOperationName.c_str(), ulMessageSize, SnaccTelemetryData::Outcome::RESULT, SnaccTelemetryData::Stage::INBOUND_RESPONSE, SnaccTelemetryData::Reason::REMOTE_RESULT, ROSE_NOERROR));
 }
 
-void SnaccROSEBase::OnErrorMessage(const SNACC::ROSEError* perror)
+void SnaccROSEBase::OnErrorMessage(SNACC::ROSEError* perror, unsigned long ulMessageSize)
 {
+	unsigned int uiOperationID = 0;
+	std::string strOperationName;
+	GetPendingOperationTelemetryInfo(perror->invokedID, uiOperationID, strOperationName);
+	OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, strOperationName.c_str(), ulMessageSize, SnaccTelemetryData::Outcome::ERR, SnaccTelemetryData::Stage::INBOUND_RESPONSE, SnaccTelemetryData::Reason::REMOTE_ERROR, ROSE_ERROR_VALUE));
 }
 
-void SnaccROSEBase::OnRejectMessage(const SNACC::ROSEReject* preject)
+void SnaccROSEBase::OnRejectMessage(SNACC::ROSEReject* preject, unsigned long ulMessageSize)
 {
+	unsigned int uiOperationID = 0;
+	std::string strOperationName;
+	if (preject->invokedID.choiceId == ROSERejectChoice::invokedIDCid && preject->invokedID.invokedID != nullptr)
+		GetPendingOperationTelemetryInfo(*preject->invokedID.invokedID, uiOperationID, strOperationName);
+	OnInvokeProcessed(SnaccTelemetryData::CreateFinalized(SnaccTelemetryData::Direction::INBOUND, uiOperationID, strOperationName.c_str(), ulMessageSize, SnaccTelemetryData::Outcome::REJECT, SnaccTelemetryData::Stage::INBOUND_RESPONSE, SnaccTelemetryData::Reason::REMOTE_REJECT, GetRejectResultCode(preject)));
 }
 
 long SnaccROSEBase::GetNextInvokeID()
@@ -895,9 +1297,11 @@ long SnaccROSEBase::GetNextInvokeID()
 	return m_lInvokeCounter;
 }
 
-long SnaccROSEBase::Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext* pCtx /*= nullptr*/)
+long SnaccROSEBase::Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext& ctx, size_t* pstRequestData /*= nullptr*/)
 {
 	long lRoseResult = ROSE_NOERROR;
+	if (pstRequestData)
+		*pstRequestData = 0;
 
 	ROSEMessage invokeMsg;
 	invokeMsg.choiceId = ROSEMessage::invokeCid;
@@ -907,9 +1311,11 @@ long SnaccROSEBase::Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName
 	{
 		unsigned long ulSize;
 		std::string strData = GetEncoded(m_eTransportEncoding, &invokeMsg, &ulSize);
+		if (pstRequestData)
+			*pstRequestData = ulSize;
 		LogTransportData(true, m_eTransportEncoding, szOperationName, strData.c_str(), ulSize, &invokeMsg, nullptr);
 
-		lRoseResult = SendBinaryDataBlockEx(strData.c_str(), ulSize, pCtx);
+		lRoseResult = SendBinaryDataBlockEx(strData.c_str(), ulSize, ctx);
 	}
 	else if (m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING)
 	{
@@ -927,8 +1333,12 @@ long SnaccROSEBase::Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName
 			LogTransportData(true, m_eTransportEncoding, nullptr, strData.c_str(), strData.length(), &invokeMsg, nullptr);
 			if (!strPrefix.empty())
 				strData.insert(0, strPrefix);
-			lRoseResult = SendBinaryDataBlockEx(strData.c_str(), (unsigned long)strData.length(), pCtx);
+			if (pstRequestData)
+				*pstRequestData = strData.length();
+			lRoseResult = SendBinaryDataBlockEx(strData.c_str(), strData.length(), ctx);
 		}
+		else if (pstRequestData)
+			*pstRequestData = strData.length();
 	}
 	else
 	{
@@ -941,9 +1351,22 @@ long SnaccROSEBase::Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName
 	return lRoseResult;
 }
 
-long SnaccROSEBase::SendEvent(SNACC::ROSEInvoke* pinvoke, const char* szOperationName, SnaccInvokeContext* pCtx /*= nullptr*/)
+long SnaccROSEBase::SendEvent(SNACC::ROSEInvoke* pinvoke, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)
 {
-	return Send(pinvoke, szOperationName, pCtx);
+	const auto chronoCreated = std::chrono::steady_clock::now();
+	const char* szResolvedOperationName = SnaccRoseOperationLookup::LookUpName(pinvoke->operationID);
+	if (!pCtx)
+	{
+		SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, pinvoke, szResolvedOperationName ? szResolvedOperationName : szOperationName);
+		pCtx = SnaccInvokeContext::Create(init);
+	}
+	auto& ctx = *pCtx;
+	size_t stRequestData = 0;
+	const long lRoseResult = Send(pinvoke, szOperationName, ctx, &stRequestData);
+	auto telemetry = SnaccTelemetryData::Create(SnaccTelemetryData::Direction::OUTBOUND, pinvoke->operationID, szResolvedOperationName, stRequestData, chronoCreated);
+	telemetry->finalize(lRoseResult == ROSE_NOERROR ? SnaccTelemetryData::Outcome::EVENT : SnaccTelemetryData::Outcome::UNHANDLED, SnaccTelemetryData::Stage::OUTBOUND_SEND, lRoseResult == ROSE_NOERROR ? SnaccTelemetryData::Reason::LOCAL_EVENT : GetUnhandledReasonFromResult(lRoseResult), lRoseResult, std::nullopt, pCtx);
+	OnInvokeProcessed(telemetry);
+	return lRoseResult;
 }
 
 bool SnaccROSEBase::LogTransportData(const bool bOutbound, const SNACC::TransportEncoding encoding, const char* szOperationName, const char* szData, const size_t size, const SNACC::ROSEMessage* pMsg, const SJson::Value* pParsedValue)
@@ -1031,13 +1454,24 @@ bool SnaccROSEBase::LogTransportData(const bool bOutbound, const SNACC::Transpor
 	return bTransportDataWasLogged;
 }
 
-long SnaccROSEBase::SendInvoke(SNACC::ROSEInvoke* pinvoke, const SNACC::ROSEMessage** pResponse, const char* szOperationName = nullptr, int iTimeout /*= -1*/, SnaccInvokeContext* pCtx /*= nullptr*/)
+long SnaccROSEBase::SendInvoke(SNACC::ROSEInvoke* pinvoke, SNACC::AsnType* result, SNACC::AsnType* error, const char* szOperationName /*= nullptr*/, int iTimeout /*= -1*/, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)
 {
-	SnaccROSEPendingOperation* pendingOP = new SnaccROSEPendingOperation;
-	pendingOP->m_lInvokeID = pinvoke->invokeID;
-	AddPendingOperation(pendingOP->m_lInvokeID, pendingOP);
+	const auto chronoCreated = std::chrono::steady_clock::now();
+	const char* szResolvedOperationName = SnaccRoseOperationLookup::LookUpName(pinvoke->operationID);
 
-	long lRoseResult = Send(pinvoke, szOperationName, pCtx);
+	// Ensure that we always have a ctx
+	if (!pCtx)
+	{
+		SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, pinvoke, szResolvedOperationName ? szResolvedOperationName : szOperationName);
+		pCtx = SnaccInvokeContext::Create(init);
+	}
+	auto& ctx = *pCtx;
+
+	auto& pendingOP = AddPendingOperation(pinvoke->invokeID, pinvoke->operationID, szResolvedOperationName);
+
+	size_t stRequestData = 0;
+	long lRoseResult = Send(pinvoke, szOperationName, ctx, &stRequestData);
+	pendingOP.m_pTelemetry = SnaccTelemetryData::Create(SnaccTelemetryData::Direction::OUTBOUND, pinvoke->operationID, szResolvedOperationName, stRequestData, chronoCreated);
 
 	if (lRoseResult == 0)
 	{
@@ -1047,38 +1481,42 @@ long SnaccROSEBase::SendInvoke(SNACC::ROSEInvoke* pinvoke, const SNACC::ROSEMess
 
 		if (iTimeout)
 		{
-			if (pendingOP->WaitForComplete(iTimeout))
+			if (pendingOP.WaitForComplete(iTimeout))
 			{
-				lRoseResult = pendingOP->m_lRoseResult;
-				if (pendingOP->m_pAnswerMessage)
-				{
-					*pResponse = pendingOP->m_pAnswerMessage;
-					pendingOP->m_pAnswerMessage = nullptr;
+				const bool bHasResponseMessage = pendingOP.m_pAnswerMessage != nullptr;
+				if (bHasResponseMessage)
 					lRoseResult = ROSE_NOERROR;
-				}
+				else
+					lRoseResult = pendingOP.m_lRoseResult;
 			}
 			else
 			{
 				// not completed
 				lRoseResult = ROSE_TE_TIMEOUT;
+				pendingOP.m_lRoseResult = lRoseResult;
 			}
 		}
 		else
 		{
 			lRoseResult = ROSE_NOERROR;
+			pendingOP.m_lRoseResult = lRoseResult;
 		}
 	}
 	else
-	{
-		lRoseResult = ROSE_TE_TRANSPORTFAILED;
-	}
-	RemovePendingOperation(pendingOP->m_lInvokeID);
-	delete pendingOP;
+		pendingOP.m_lRoseResult = lRoseResult;
+
+	if (pendingOP.m_pAnswerMessage)
+		lRoseResult = HandleInvokeResult(lRoseResult, pendingOP.m_pAnswerMessage, result, error, ctx);
+
+	pendingOP.FinalizeTelemetry(pCtx);
+	OnInvokeProcessed(pendingOP.m_pTelemetry);
+
+	RemovePendingOperation(pendingOP.m_lInvokeID);
 
 	return lRoseResult;
 }
 
-long SnaccROSEBase::DecodeResponse(const SNACC::ROSEMessage* pResponse, SNACC::ROSEResult** ppResult, SNACC::ROSEError** ppError, SnaccInvokeContext* pCtx)
+long SnaccROSEBase::DecodeResponse(const SNACC::ROSEMessage* pResponse, SNACC::ROSEResult** ppResult, SNACC::ROSEError** ppError, SnaccInvokeContext& ctx)
 {
 	long lRoseResult = ROSE_RE_INVALID_ANSWER;
 	if (!pResponse)
@@ -1099,189 +1537,137 @@ long SnaccROSEBase::DecodeResponse(const SNACC::ROSEMessage* pResponse, SNACC::R
 				*ppError = pResponse->error;
 			break;
 		case ROSEMessage::rejectCid:
-			lRoseResult = ROSE_REJECT_UNKNOWN;
-			if (pResponse->reject && pResponse->reject->reject)
-			{
-				if (pResponse->reject->reject->choiceId == RejectProblem::invokeProblemCid)
-				{
-					if (*pResponse->reject->reject->invokeProblem == InvokeProblem::unrecognisedOperation)
-						lRoseResult = ROSE_REJECT_UNKNOWNOPERATION;
-					else if (*pResponse->reject->reject->invokeProblem == InvokeProblem::mistypedArgument)
-						lRoseResult = ROSE_REJECT_MISTYPEDARGUMENT;
-					else if (*pResponse->reject->reject->invokeProblem == InvokeProblem::resourceLimitation)
-						lRoseResult = ROSE_REJECT_FUNCTIONMISSING;
-					else if (*pResponse->reject->reject->invokeProblem == InvokeProblem::authenticationIncomplete)
-					{
-						lRoseResult = ROSE_REJECT_AUTHENTICATIONINCOMPLETE;
-						if (pCtx)
-						{
-							if (pResponse->reject->authentication)
-								pCtx->pRejectAuth = (SNACC::ROSEAuthResult*)pResponse->reject->authentication->Clone();
-							pCtx->lRejectResult = ROSE_REJECT_AUTHENTICATIONINCOMPLETE;
-						}
-					}
-					else if (*pResponse->reject->reject->invokeProblem == InvokeProblem::authenticationFailed)
-					{
-						lRoseResult = ROSE_REJECT_AUTHENTICATIONFAILED;
-						if (pCtx)
-						{
-							if (pResponse->reject->authentication)
-								pCtx->pRejectAuth = (SNACC::ROSEAuthResult*)pResponse->reject->authentication->Clone();
-							pCtx->lRejectResult = ROSE_REJECT_AUTHENTICATIONFAILED;
-						}
-					}
-				}
-			}
+			lRoseResult = GetRejectResultCode(pResponse->reject, ctx);
 			break;
 	}
 
 	return lRoseResult;
 }
 
-long SnaccROSEBase::SendResult(SNACC::ROSEResult* presult)
-{
-	long lRoseResult = ROSE_NOERROR;
-
-	ROSEMessage ResultMsg;
-	ResultMsg.choiceId = ROSEMessage::resultCid;
-	ResultMsg.result = presult;
-
-	// encode now.
-	if (m_eTransportEncoding == SNACC::TransportEncoding::BER)
-	{
-		AsnBuf OutBuf;
-		AsnLen BytesEncoded = ResultMsg.BEnc(OutBuf);
-
-		std::string strData;
-		OutBuf.ResetMode();
-		OutBuf.GetSeg(strData, BytesEncoded);
-
-		LogTransportData(true, m_eTransportEncoding, nullptr, strData.c_str(), BytesEncoded, &ResultMsg, nullptr);
-
-		lRoseResult = SendBinaryDataBlockEx(strData.c_str(), BytesEncoded, nullptr);
-	}
-	else if (m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING)
-	{
-		auto value = ResultMsg.JEnc();
-
-		std::string strData;
-		int logLevel = (int)GetLogLevel(true);
-		if (logLevel & (int)EAsnLogLevel::JSON || logLevel & (int)EAsnLogLevel::JSON_ALWAYS_PRETTY_PRINTED)
-			strData = getPrettyPrinted(value);
-		else
-		{
-			SJson::FastWriter writer;
-			strData = writer.write(value);
-		}
-
-		std::string strPrefix;
-		if (m_eTransportEncoding == SNACC::TransportEncoding::JSON)
-			lRoseResult = GetJsonLengthPrefix(strData, strPrefix);
-		if (lRoseResult == ROSE_NOERROR)
-		{
-			LogTransportData(true, m_eTransportEncoding, nullptr, strData.c_str(), strData.length(), &ResultMsg, nullptr);
-			if (!strPrefix.empty())
-				strData.insert(0, strPrefix);
-			lRoseResult = SendBinaryDataBlockEx(strData.c_str(), (unsigned long)strData.length(), nullptr);
-		}
-	}
-	else
-	{
-		throw std::runtime_error("invalid m_eTransportEncoding");
-	}
-
-	// prevent delete of presult...
-	ResultMsg.result = 0;
-
-	return lRoseResult;
-}
-
-long SnaccROSEBase::SendResult(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, const wchar_t* szSessionID /* = 0 */)
+long SnaccROSEBase::EncodeResult(unsigned int uiInvokeID, SNACC::AsnType* pResult, std::string& strResponse, const wchar_t* szSessionID /*= nullptr*/)
 {
 	long lRoseResult = ROSE_NOERROR;
 
 	ROSEResult result;
-	result.invokeID = pInvoke->invokeID;
+	result.invokeID = uiInvokeID;
 	result.result = new ROSEResultSeq;
 	result.result->resultValue = 0;
 	result.result->result.value = pResult;
 	if (szSessionID)
 		result.sessionID = new UTF8String(szSessionID);
 
-	lRoseResult = SendResult(&result);
-
-	// prevent delete of value...
-	result.result->result.value = 0;
-
-	return lRoseResult;
-}
-
-long SnaccROSEBase::EncodeError(const SNACC::ROSEError* perror, std::string& strResponse)
-{
-	long lRoseResult = ROSE_NOERROR;
-
-	ROSEMessage errorMsg;
-	errorMsg.choiceId = ROSEMessage::errorCid;
-	errorMsg.error = (SNACC::ROSEError*)perror;
-
-	// encode now.
-	if (m_eTransportEncoding == SNACC::TransportEncoding::BER)
 	{
-		AsnBuf OutBuf;
-		AsnLen BytesEncoded = errorMsg.BEnc(OutBuf);
+		ROSEMessage ResultMsg;
+		ResultMsg.choiceId = ROSEMessage::resultCid;
+		ResultMsg.result = &result;
 
-		OutBuf.ResetMode();
-		OutBuf.GetSeg(strResponse, BytesEncoded);
+		// encode now.
+		if (m_eTransportEncoding == SNACC::TransportEncoding::BER)
+		{
+			AsnBuf OutBuf;
+			AsnLen BytesEncoded = ResultMsg.BEnc(OutBuf);
 
-		LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), strResponse.length(), &errorMsg, nullptr);
-	}
-	else if (m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING)
-	{
-		auto value = errorMsg.JEnc();
+			OutBuf.ResetMode();
+			OutBuf.GetSeg(strResponse, BytesEncoded);
 
-		int logLevel = (int)GetLogLevel(true);
-		if (logLevel & (int)EAsnLogLevel::JSON || logLevel & (int)EAsnLogLevel::JSON_ALWAYS_PRETTY_PRINTED)
-			strResponse = getPrettyPrinted(value);
+			LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), BytesEncoded, &ResultMsg, nullptr);
+		}
+		else if (m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING)
+		{
+			auto value = ResultMsg.JEnc();
+
+			int logLevel = (int)GetLogLevel(true);
+			if (logLevel & (int)EAsnLogLevel::JSON || logLevel & (int)EAsnLogLevel::JSON_ALWAYS_PRETTY_PRINTED)
+				strResponse = getPrettyPrinted(value);
+			else
+			{
+				SJson::FastWriter writer;
+				strResponse = writer.write(value);
+			}
+
+			std::string strPrefix;
+			if (m_eTransportEncoding == SNACC::TransportEncoding::JSON)
+				lRoseResult = GetJsonLengthPrefix(strResponse, strPrefix);
+			if (lRoseResult == ROSE_NOERROR)
+			{
+				LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), strResponse.length(), &ResultMsg, nullptr);
+				if (!strPrefix.empty())
+					strResponse.insert(0, strPrefix);
+			}
+		}
 		else
 		{
-			SJson::FastWriter writer;
-			strResponse = writer.write(value);
+			throw std::runtime_error("invalid m_eTransportEncoding");
 		}
 
-		std::string strPrefix;
-		if (m_eTransportEncoding == SNACC::TransportEncoding::JSON)
-			lRoseResult = GetJsonLengthPrefix(strResponse, strPrefix);
-		if (lRoseResult == ROSE_NOERROR)
-		{
-			LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), strResponse.length(), &errorMsg, nullptr);
-			if (!strPrefix.empty())
-				strResponse.insert(0, strPrefix);
-		}
-	}
-	else
-	{
-		throw std::runtime_error("invalid m_eTransportEncoding");
+		// prevent delete of presult...
+		ResultMsg.result = nullptr;
 	}
 
-	// prevent delete of perror...
-	errorMsg.error = nullptr;
+	// prevent delete of value...
+	result.result->result.value = nullptr;
 
 	return lRoseResult;
 }
 
-long SnaccROSEBase::EncodeError(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pError, const wchar_t* szSessionID, std::string& strResponse)
+long SnaccROSEBase::EncodeError(unsigned int uiInvokeID, SNACC::AsnType* pError, std::string& strResponse, const wchar_t* szSessionID /*= nullptr*/)
 {
 	long lRoseResult = ROSE_NOERROR;
 
 	ROSEError error;
-	error.invokedID = pInvoke->invokeID;
+	error.invokedID = uiInvokeID;
 	error.error_value = 0;
-	error.error = new AsnAny;
+	error.error = new AsnAny();
 	error.error->value = pError;
 	if (szSessionID)
 		error.sessionID = new UTF8String(szSessionID);
 
-	lRoseResult = EncodeError(&error, strResponse);
+	{
+		ROSEMessage errorMsg;
+		errorMsg.choiceId = ROSEMessage::errorCid;
+		errorMsg.error = &error;
+
+		// encode now.
+		if (m_eTransportEncoding == SNACC::TransportEncoding::BER)
+		{
+			AsnBuf OutBuf;
+			AsnLen BytesEncoded = errorMsg.BEnc(OutBuf);
+
+			OutBuf.ResetMode();
+			OutBuf.GetSeg(strResponse, BytesEncoded);
+
+			LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), strResponse.length(), &errorMsg, nullptr);
+		}
+		else if (m_eTransportEncoding == SNACC::TransportEncoding::JSON || m_eTransportEncoding == SNACC::TransportEncoding::JSON_NO_HEADING)
+		{
+			auto value = errorMsg.JEnc();
+
+			int logLevel = (int)GetLogLevel(true);
+			if (logLevel & (int)EAsnLogLevel::JSON || logLevel & (int)EAsnLogLevel::JSON_ALWAYS_PRETTY_PRINTED)
+				strResponse = getPrettyPrinted(value);
+			else
+			{
+				SJson::FastWriter writer;
+				strResponse = writer.write(value);
+			}
+
+			std::string strPrefix;
+			if (m_eTransportEncoding == SNACC::TransportEncoding::JSON)
+				lRoseResult = GetJsonLengthPrefix(strResponse, strPrefix);
+			if (lRoseResult == ROSE_NOERROR)
+			{
+				LogTransportData(true, m_eTransportEncoding, nullptr, strResponse.c_str(), strResponse.length(), &errorMsg, nullptr);
+				if (!strPrefix.empty())
+					strResponse.insert(0, strPrefix);
+			}
+		}
+		else
+		{
+			throw std::runtime_error("invalid m_eTransportEncoding");
+		}
+		// prevent delete of perror...
+		errorMsg.error = nullptr;
+	}
 
 	// prevent delete of value...
 	error.error->value = nullptr;
@@ -1289,10 +1675,10 @@ long SnaccROSEBase::EncodeError(const SNACC::ROSEInvoke* pInvoke, SNACC::AsnType
 	return lRoseResult;
 }
 
-long SnaccROSEBase::SendBinaryDataBlockEx(const char* lpBytes, unsigned long lSize, SnaccInvokeContext* pCtx)
+long SnaccROSEBase::SendBinaryDataBlockEx(const char* lpBytes, size_t size, SnaccInvokeContext& ctx)
 {
 	if (m_pTransport)
-		return m_pTransport->SendBinaryDataBlockEx(lpBytes, lSize, pCtx);
+		return m_pTransport->SendBinaryDataBlockEx(lpBytes, size, ctx);
 	return ROSE_TE_TRANSPORTFAILED;
 }
 
@@ -1316,7 +1702,7 @@ SNACC::TransportEncoding SnaccROSEBase::GetTransportEncoding() const
 	return m_eTransportEncoding;
 }
 
-long SnaccROSEBase::HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage* pResponseMsg, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext* pCtx)
+long SnaccROSEBase::HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage* pResponseMsg, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext& ctx)
 {
 	// In case of transport errors, we hand that value back as we have no response to parse
 	if (ISROSE_TE(lRoseResult))
@@ -1324,7 +1710,7 @@ long SnaccROSEBase::HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessag
 
 	SNACC::ROSEError* pError = nullptr;
 	SNACC::ROSEResult* pResult = nullptr;
-	lRoseResult = DecodeResponse(pResponseMsg, &pResult, &pError, pCtx);
+	lRoseResult = DecodeResponse(pResponseMsg, &pResult, &pError, ctx);
 
 	if (lRoseResult == ROSE_NOERROR)
 	{
@@ -1433,15 +1819,28 @@ long SnaccROSEBase::HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessag
 		}
 	}
 
-	if (pResponseMsg)
-		delete pResponseMsg;
-
 	return lRoseResult;
 }
 
-long SnaccROSEBase::HandleOnInvokeResult(SNACC::InvokeResult invokeResult, std::string& strResponse, SNACC::AsnType* result, SNACC::AsnType* error, SnaccInvokeContext* cxt)
+long SnaccROSEBase::HandleOnInvokeResult(SNACC::InvokeResult invokeResult, const SNACC::ROSEInvoke* pInvoke, SnaccInvokeContext& ctx, std::string& strResponse, SNACC::AsnType* pResult, SNACC::AsnType* pError)
 {
-	return 0;
+	if (pInvoke && (AsnIntType)pInvoke->invokeID == 99999)
+	{
+		strResponse.clear();
+		ctx.m_bResponseIsError = false;
+		return ROSE_NOERROR;
+	}
+
+	switch (invokeResult)
+	{
+		case InvokeResult::returnResult:
+			return EncodeResult(pInvoke->invokeID, pResult, strResponse);
+		case InvokeResult::returnError:
+			ctx.m_bResponseIsError = true;
+			return EncodeError(pInvoke->invokeID, pError, strResponse);
+		default:
+			return ctx.m_lRejectResult ? ctx.m_lRejectResult : ROSE_REJECT_FUNCTIONMISSING;
+	}
 }
 
 long SnaccROSEBase::DecodeInvoke(const SNACC::ROSEMessage* pMessage, SNACC::AsnType* argument)
@@ -1577,14 +1976,14 @@ int SnaccROSEBase::ConfigureFileLogging(const LOG_CHARTYPE* szPath, bool bAppend
 	return 0;
 }
 
-bool SnaccROSEBase::PrintJSONToLog(const bool bOutbound, const bool bError, const char* szOperationName, const char* szData, const size_t stLength)
+bool SnaccROSEBase::PrintJSONToLog(const bool bOutbound, const bool bError, const char* szOperationName, const char* szData, const size_t size)
 {
 	if (!m_pAsnLogFile || !szData)
 		return false;
 
-	// Die ASN.1-Funktionen k�nnen auch aus verschiedenen Threads gerufen werden.
-	// Das Schreiben in die roseout.log muss aber damit serialisiert werden.
-	// Der Lock sollte nicht schaden, da nur die Datei selbst gelockt wird und kein anderes Objekt (PAIM-1732).
+	// The ASN.1 functions may be called from different threads as well.
+	// Writing to roseout.log therefore has to be serialized.
+	// The lock should not hurt, as only the file itself is locked and no other object (PAIM-1732).
 	std::lock_guard<std::mutex> lock(m_mtxLogFile);
 
 	// Securly check the logfile pointer once more after aquiring the lock
@@ -1627,7 +2026,7 @@ bool SnaccROSEBase::PrintJSONToLog(const bool bOutbound, const bool bError, cons
 		if (*szData == '{' || *szData == '[')
 			fprintf(m_pAsnLogFile, "\t\"%s\" : \n", bError ? "ERROR" : "ROSE");
 
-		size_t stPrintLength = stLength;
+		size_t stPrintLength = size;
 		if (!stPrintLength)
 		{
 			try
@@ -1684,4 +2083,10 @@ bool SnaccROSEBase::PrintJSONToLog(const bool bOutbound, const bool bError, cons
 		ASSERT(false);
 	}
 	return false;
+}
+
+void SnaccROSEBase::OnInvokeProcessed(std::shared_ptr<const SnaccTelemetryData> data)
+{
+	if (m_pTelemetryCallback)
+		m_pTelemetryCallback->OnInvokeProcessed(data);
 }

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -1524,6 +1524,8 @@ long SnaccROSEBase::DecodeResponse(const SNACC::ROSEMessage* pResponse, SNACC::R
 
 	switch (pResponse->choiceId)
 	{
+		case ROSEMessage::notinitialized:
+			throw std::runtime_error("response ROSEMessage choiceId is notinitialized");
 		case ROSEMessage::invokeCid:
 			break;
 		case ROSEMessage::resultCid:

--- a/cpp-lib/src/SnaccTelemetry.cpp
+++ b/cpp-lib/src/SnaccTelemetry.cpp
@@ -1,0 +1,147 @@
+#include "../include/SnaccTelemetry.h"
+#include "snacc-assert.h"
+#include <stdexcept>
+
+const char* SnaccTelemetryData::GetDebugText(Direction direction)
+{
+	switch (direction)
+	{
+		case Direction::INBOUND:
+			return "INBOUND";
+		case Direction::OUTBOUND:
+			return "OUTBOUND";
+		default:
+			ASSERT(0);
+			return "INVALID_DIRECTION";
+	}
+}
+
+const char* SnaccTelemetryData::GetDebugText(Outcome outcome)
+{
+	switch (outcome)
+	{
+		case Outcome::RESULT:
+			return "RESULT";
+		case Outcome::ERR:
+			return "ERR";
+		case Outcome::REJECT:
+			return "REJECT";
+		case Outcome::EVENT:
+			return "EVENT";
+		case Outcome::UNHANDLED:
+			return "UNHANDLED";
+		default:
+			ASSERT(0);
+			return "INVALID_OUTCOME";
+	}
+}
+
+const char* SnaccTelemetryData::GetDebugText(Stage stage)
+{
+	switch (stage)
+	{
+		case Stage::UNKNOWN:
+			return "UNKNOWN";
+		case Stage::INBOUND_DECODE:
+			return "INBOUND_DECODE";
+		case Stage::INBOUND_INVOKE:
+			return "INBOUND_INVOKE";
+		case Stage::INBOUND_RESPONSE:
+			return "INBOUND_RESPONSE";
+		case Stage::OUTBOUND_SEND:
+			return "OUTBOUND_SEND";
+		case Stage::OUTBOUND_WAIT:
+			return "OUTBOUND_WAIT";
+		default:
+			ASSERT(0);
+			return "INVALID_STAGE";
+	}
+}
+
+const char* SnaccTelemetryData::GetDebugText(Reason reason)
+{
+	switch (reason)
+	{
+		case Reason::NONE:
+			return "NONE";
+		case Reason::LOCAL_RESULT:
+			return "LOCAL_RESULT";
+		case Reason::LOCAL_ERROR:
+			return "LOCAL_ERROR";
+		case Reason::LOCAL_REJECT:
+			return "LOCAL_REJECT";
+		case Reason::LOCAL_EVENT:
+			return "LOCAL_EVENT";
+		case Reason::REMOTE_RESULT:
+			return "REMOTE_RESULT";
+		case Reason::REMOTE_ERROR:
+			return "REMOTE_ERROR";
+		case Reason::REMOTE_REJECT:
+			return "REMOTE_REJECT";
+		case Reason::DECODE_FAILED:
+			return "DECODE_FAILED";
+		case Reason::ENCODE_FAILED:
+			return "ENCODE_FAILED";
+		case Reason::SEND_FAILED:
+			return "SEND_FAILED";
+		case Reason::TIMEOUT:
+			return "TIMEOUT";
+		case Reason::SHUTDOWN:
+			return "SHUTDOWN";
+		case Reason::INVALID_RESPONSE:
+			return "INVALID_RESPONSE";
+		case Reason::WAIT_SKIPPED:
+			return "WAIT_SKIPPED";
+		case Reason::INVOKE_EXCEPTION:
+			return "INVOKE_EXCEPTION";
+		case Reason::UNKNOWN_FAILURE:
+			return "UNKNOWN_FAILURE";
+		default:
+			ASSERT(0);
+			return "INVALID_REASON";
+	}
+}
+
+std::shared_ptr<SnaccTelemetryData> SnaccTelemetryData::Create(Direction direction, unsigned int uiOperationID, const char* szOperationName, size_t stRequestData, std::chrono::steady_clock::time_point chronoCreated /*= std::chrono::steady_clock::now()*/)
+{
+	return std::shared_ptr<SnaccTelemetryData>(new SnaccTelemetryData(direction, uiOperationID, szOperationName, stRequestData, chronoCreated));
+}
+
+std::shared_ptr<SnaccTelemetryData> SnaccTelemetryData::CreateFinalized(Direction direction, unsigned int uiOperationID, const char* szOperationName, size_t stRequestData, Outcome outcome, Stage stage, Reason reason, long lRoseResult, std::optional<size_t> stResponseData /*= std::nullopt*/, std::shared_ptr<SnaccInvokeContext> pctx /*= {}*/, std::chrono::steady_clock::time_point chronoCreated /*= std::chrono::steady_clock::now()*/)
+{
+	auto telemetry = Create(direction, uiOperationID, szOperationName, stRequestData, chronoCreated);
+	telemetry->finalize(outcome, stage, reason, lRoseResult, stResponseData, pctx);
+	return telemetry;
+}
+
+void SnaccTelemetryData::finalize(Outcome outcome, Stage stage, Reason reason, std::optional<long> lRoseResult /*= std::nullopt*/, std::optional<size_t> stResponseData /*= std::nullopt*/, std::shared_ptr<SnaccInvokeContext> pctx /*= {}*/)
+{
+	ASSERT(!m_bFinalized);
+	if (m_bFinalized)
+		throw std::logic_error("SnaccTelemetryData::finalize may only be called once");
+
+	std::shared_ptr<SnaccInvokeContext> pTelemetryctx;
+	if (pctx)
+	{
+		pTelemetryctx = pctx->Clone();
+		pTelemetryctx->PrepareForTelemetry();
+	}
+
+	m_Duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_ChronoCreated);
+	m_Outcome = outcome;
+	m_Stage = stage;
+	m_Reason = reason;
+	m_lRoseResult = lRoseResult;
+	m_stResponseData = stResponseData;
+	m_pctx = std::move(pTelemetryctx);
+	m_bFinalized = true;
+}
+
+SnaccTelemetryData::SnaccTelemetryData(Direction direction, unsigned int uiOperationID, const char* szOperationName, size_t stRequestData, std::chrono::steady_clock::time_point chronoCreated)
+	: m_Direction(direction),
+	  m_uiOperationID(uiOperationID),
+	  m_strOperationName(szOperationName ? szOperationName : ""),
+	  m_stRequestData(stRequestData),
+	  m_ChronoCreated(chronoCreated)
+{
+}


### PR DESCRIPTION
## Summary
- normalize touched files to ASCII-friendly text and remove BOMs so the later refactor is easier to review and less noisy
- introduce `SnaccTelemetryData` as the common ROSE telemetry payload and route inbound/outbound lifecycle reporting through a single finalized model
- restructure inbound ROSE handling so response encoding/sending, reject handling, and telemetry finalization happen in the core runtime instead of inside generated handlers
- refactor `SnaccInvokeContext` into a first-class extensible runtime object with factory creation, clone/copy support, mutable live flow, and const telemetry retention
- rework outbound invoke/event handling and generated C++ ROSE stubs to use shared context ownership, cleaner send paths, deprecated-call context propagation, and simpler generated method bodies
- align compiler/runtime support code and generated artifacts with the new telemetry/context model, including updated TypeScript glue code, runtime interfaces, and sample inputs

## Details
- add `SnaccTelemetry.h/.cpp` and replace the older telemetry payload shape with direction/outcome/stage/reason based telemetry finalization
- retain a const telemetry snapshot of the invoke context while keeping the live invoke context mutable through runtime, transport, and deprecated-call hooks
- add debug text helpers for telemetry enums to simplify logging and diagnostics
- move `SnaccInvokeContext` into the shared ROSE interfaces, add factory-based construction, clone support, and derived-type copy support
- make outbound context sharing observable to callers by switching the live context path to `shared_ptr`
- simplify generated C++ ROSE methods to return `SendInvoke` / `SendEvent` directly and document defaulted parameters in the generated `.cpp`
- introduce scoped ROSE invoke setup/cleanup helpers in the runtime to reduce generated boilerplate
- update generated and runtime naming/comments/documentation so parameter names and behavior stay aligned after the refactor

## Test plan
- [x] build `cpp-lib` in `Debug`
- [x] build `cpp-lib` in `Release`
- [x] build `compiler` in `Debug`
- [x] build `compiler` in `Release`
- [x] regenerate representative C++ ROSE sample stubs with the updated compiler
- [x] compile the regenerated `generator-check` sample successfully
- [x] verify the rewritten branch content matches the original WIP result after history cleanup