### PR TITLE
UCAAS-1333: snacclib7 ROSE handler and invoke context improvements

### DIFF
--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -1180,9 +1180,8 @@ static void PrintROSEOnInvokeHandler(FILE* src, int bEvents, Module* mod, ValueD
 			fprintf(src, "// [%s] OPID_%s\n", __FUNCTION__, vd->definedName);
 			fprintf(src, "static long %s_OPID_%s(SNACC::ROSEMessage* pMsg, SNACC::ROSEInvoke* pInvoke, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext& ctx, std::string& strResponseData)\n", pszHandlerPrefix, vd->definedName, mod->ROSEClassName);
 			fprintf(src, "{\n");
-			fprintf(src, "\tlong lRoseResult = ROSE_NOERROR;\n");
 			fprintf(src, "\t%s argument;\n", pszArgument);
-			fprintf(src, "\tlRoseResult = pBase->DecodeInvoke(pMsg, &argument);\n");
+			fprintf(src, "\tlong lRoseResult = pBase->DecodeInvoke(pMsg, &argument);\n");
 			fprintf(src, "\tif (lRoseResult == ROSE_NOERROR)\n");
 			const bool bIsDeprecated = IsDeprecatedFlaggedOperation(mod, vd->definedName);
 			const bool bIsMultiLine = bIsDeprecated || pszResult;
@@ -4624,8 +4623,6 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	fprintf(hdr, "\tstatic long OnInvoke(SNACC::ROSEMessage* pMsg, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext& ctx, std::string& strResponseData);\n", m->ROSEClassName);
 	fprintf(src, "long %s::OnInvoke(SNACC::ROSEMessage* pMsg, SnaccROSESender* pBase, %sInterface* pInt, SnaccInvokeContext& ctx, std::string& strResponseData)\n", m->ROSEClassName, m->ROSEClassName);
 	fprintf(src, "{\n");
-	fprintf(src, "\tlong lRoseResult = ROSE_REJECT_UNKNOWNOPERATION;\n");
-	fprintf(src, "\n");
 	fprintf(src, "\tauto pInvoke = pMsg->invoke;\n");
 	fprintf(src, "\tswitch (pInvoke->operationID)\n");
 	fprintf(src, "\t{\n");
@@ -4646,8 +4643,9 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 			PrintROSEOnInvokeswitchCase(src, 1, m, vd);
 	}
 
+	fprintf(src, "\tdefault:\n");
+	fprintf(src, "\t\treturn ROSE_REJECT_UNKNOWNOPERATION;\n");
 	fprintf(src, "\t}\n");
-	fprintf(src, "\treturn lRoseResult;\n");
 	fprintf(src, "}\n");
 	fprintf(src, "\n");
 

--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -219,7 +219,7 @@ public:
 
 	/* Send a Reject Message. */
 	long EncodeReject(SNACC::ROSEReject* preject, std::string& strResponse);
-	long SendRejectEx(SNACC::ROSEReject* preject);
+	long SendRejectEx(SNACC::ROSEReject* preject, SnaccInvokeContext& ctx);
 
 	/*
 	 * Encodes a reject as repsonse to an invoke
@@ -265,11 +265,11 @@ public:
 	/**
 	 * An invoke that is send to the other side. Should only be called by the ROSE stub itself generated files
 	 *
-	 * pInvoke - the invoke payload (it is put into a ROSEMessage in the function)
+	 * pinvoke - the invoke payload (it is put into a ROSEMessage in the function)
 	 * result - decoded result payload in case a result response is received
 	 * error - decoded error payload in case an error response is received
 	 * szOperationName - the operationName (for logging purposes)
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don't care about the result))
+	 * iTimeout - the timeout in milliseconds (-1 uses default m_lMaxInvokeWait, 0 returns immediately without waiting for the result)
 	 * pCtx - contextual data for the invoke. The caller may keep another shared reference
 	 *        to inspect changes after the call.
 	 */

--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -212,7 +212,7 @@ public:
 	 * result - decoded result payload in case a result response is received
 	 * error - decoded error payload in case an error response is received
 	 * szOperationName - the operationName (for logging purposes)
-	 * iTimeout - the timeout (-1 is default m_lMaxInvokeWait, 0 return immediately (don't care about the result))
+	 * iTimeout - the timeout in milliseconds (-1 uses default m_lMaxInvokeWait, 0 returns immediately without waiting for the result)
 	 * pCtx - contextual data for the invoke. The caller may keep another shared reference
 	 *        to inspect changes after the call.
 	 */

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -279,8 +279,7 @@ void SnaccROSEPendingOperation::FinalizeTelemetry(long lFinalRoseResult, std::sh
 
 	if (m_pAnswerMessage && lFinalRoseResult != m_lRoseResult)
 	{
-		m_pTelemetry->finalize(SnaccTelemetryData::Outcome::UNHANDLED, GetOutboundUnhandledStageFromResult(lFinalRoseResult), GetUnhandledReasonFromResult(lFinalRoseResult),
-			lFinalRoseResult, m_stResponseData, std::move(pctx));
+		m_pTelemetry->finalize(SnaccTelemetryData::Outcome::UNHANDLED, GetOutboundUnhandledStageFromResult(lFinalRoseResult), GetUnhandledReasonFromResult(lFinalRoseResult), lFinalRoseResult, m_stResponseData, std::move(pctx));
 		return;
 	}
 
@@ -540,7 +539,8 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 									reject.invokedID.invokednull = new AsnNull;
 								}
 
-								const long lRejectResult = SendRejectEx(&reject);
+								auto pRejectCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName));
+								const long lRejectResult = SendRejectEx(&reject, *pRejectCtx);
 								if (lRejectResult == ROSE_NOERROR)
 								{
 									outcome = SnaccTelemetryData::Outcome::REJECT;
@@ -619,7 +619,8 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 									*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
 									reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
 
-									const long lRejectResult = SendRejectEx(&reject);
+									auto pRejectCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName));
+									const long lRejectResult = SendRejectEx(&reject, *pRejectCtx);
 									if (lRejectResult == ROSE_NOERROR)
 									{
 										outcome = SnaccTelemetryData::Outcome::REJECT;
@@ -843,7 +844,8 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long ulSize,
 									reject.invokedID.invokednull = new AsnNull;
 								}
 
-								const long lRejectResult = SendRejectEx(&reject);
+								auto pRejectCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName));
+								const long lRejectResult = SendRejectEx(&reject, *pRejectCtx);
 								if (lRejectResult == ROSE_NOERROR)
 								{
 									outcome = SnaccTelemetryData::Outcome::REJECT;
@@ -919,7 +921,8 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long ulSize,
 									*reject.reject->invokeProblem = InvokeProblem::mistypedArgument;
 									reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
 
-									const long lRejectResult = SendRejectEx(&reject);
+									auto pRejectCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName));
+									const long lRejectResult = SendRejectEx(&reject, *pRejectCtx);
 									if (lRejectResult == ROSE_NOERROR)
 									{
 										outcome = SnaccTelemetryData::Outcome::REJECT;
@@ -957,7 +960,8 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long ulSize,
 						reject.details = UTF8String::CreateNewFromASCII(strError.c_str());
 						auto outcome = SnaccTelemetryData::Outcome::UNHANDLED;
 						long lTelemetryResult = ROSE_RE_DECODE_FAILED;
-						const long lRejectResult = SendRejectEx(&reject);
+						auto pRejectCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, nullptr, nullptr));
+						const long lRejectResult = SendRejectEx(&reject, *pRejectCtx);
 						if (lRejectResult == ROSE_NOERROR)
 						{
 							outcome = SnaccTelemetryData::Outcome::REJECT;
@@ -1125,16 +1129,14 @@ long SnaccROSEBase::EncodeReject(SNACC::ROSEReject* preject, std::string& strRes
 	return lRoseResult;
 }
 
-long SnaccROSEBase::SendRejectEx(SNACC::ROSEReject* preject)
+long SnaccROSEBase::SendRejectEx(SNACC::ROSEReject* preject, SnaccInvokeContext& ctx)
 {
 	std::string strResponse;
 	auto lResult = EncodeReject(preject, strResponse);
 	if (lResult)
 		return lResult;
 
-	auto ctx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND, nullptr));
-
-	return SendBinaryDataBlockEx(strResponse.c_str(), strResponse.length(), *ctx);
+	return SendBinaryDataBlockEx(strResponse.c_str(), strResponse.length(), ctx);
 }
 
 long SnaccROSEBase::GetJsonLengthPrefix(std::string_view strJson, std::string& strLenghtPrefix) const
@@ -1233,7 +1235,7 @@ void SnaccROSEBase::OnInvokeMessage(SNACC::ROSEMessage* pMessage, unsigned long 
 	const char* szOperationName = SnaccRoseOperationLookup::LookUpName(pInvoke->operationID);
 
 	SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName);
-	auto pCtx = SnaccInvokeContext::Create(init);
+	auto pCtx = CreateInvokeContext(init);
 	auto telemetry = SnaccTelemetryData::Create(SnaccTelemetryData::Direction::INBOUND, pInvoke->operationID, szOperationName, ulMessageSize);
 	auto telemetryResult = SnaccTelemetryData::Outcome::UNHANDLED;
 	auto telemetryReason = SnaccTelemetryData::Reason::UNKNOWN_FAILURE;
@@ -1416,7 +1418,7 @@ long SnaccROSEBase::SendEvent(SNACC::ROSEInvoke* pinvoke, const char* szOperatio
 	if (!pCtx)
 	{
 		SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, pinvoke, szResolvedOperationName ? szResolvedOperationName : szOperationName);
-		pCtx = SnaccInvokeContext::Create(init);
+		pCtx = CreateInvokeContext(init);
 	}
 	auto& ctx = *pCtx;
 	size_t stRequestData = 0;
@@ -1521,7 +1523,7 @@ long SnaccROSEBase::SendInvoke(SNACC::ROSEInvoke* pinvoke, SNACC::AsnType* resul
 	if (!pCtx)
 	{
 		SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, pinvoke, szResolvedOperationName ? szResolvedOperationName : szOperationName);
-		pCtx = SnaccInvokeContext::Create(init);
+		pCtx = CreateInvokeContext(init);
 	}
 	auto& ctx = *pCtx;
 

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "7.0.4"
-#define VERSION_RC 7, 0, 4
-#define RELDATE "29.06.2026"
+#define VERSION "7.0.5"
+#define VERSION_RC 7, 0, 5
+#define RELDATE "03.07.2026"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Summary

UCAAS-1333 snacclib7 / esnacc improvements (single squashed commit `ff0c2ee`):

- **Compiler:** simplify generated C++ ROSE handlers — initialize `lRoseResult` from `DecodeInvoke` and use an explicit `default` case in `OnInvoke`
- **Reject context:** require callers to pass `SnaccInvokeContext` into `SendRejectEx` so decode-error rejects use inbound invoke context instead of an empty outbound context
- **Dispatch:** route `OnInvokeMessage`, `SendEvent`, and `SendInvoke` through `CreateInvokeContext()` so transport subclasses can supply custom invoke contexts
- **Docs:** document `SendInvoke` `iTimeout` in **milliseconds** on `SnaccROSESender` and `SnaccROSEBase` (-1 → default `m_lMaxInvokeWait`, 0 → fire-and-forget)
- **Release:** bump version to **7.0.5** (release date 03.07.2026)

## Test plan
- [x] Build `cpp-lib` and `compiler` locally
- [x] Regenerate sample ROSE stubs and build `cpp-lib-sample-runtime-tests`
- [ ] Regenerate ASN.1 stubs in consuming projects (ProCall UCAAS-1333 branch) and verify inbound reject + invoke context handling