### PR TITLE
UCAAS-1333: route ROSE dispatch through CreateInvokeContext override

### DIFF
--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -1233,7 +1233,7 @@ void SnaccROSEBase::OnInvokeMessage(SNACC::ROSEMessage* pMessage, unsigned long 
 	const char* szOperationName = SnaccRoseOperationLookup::LookUpName(pInvoke->operationID);
 
 	SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, pInvoke, szOperationName);
-	auto pCtx = SnaccInvokeContext::Create(init);
+	auto pCtx = CreateInvokeContext(init);
 	auto telemetry = SnaccTelemetryData::Create(SnaccTelemetryData::Direction::INBOUND, pInvoke->operationID, szOperationName, ulMessageSize);
 	auto telemetryResult = SnaccTelemetryData::Outcome::UNHANDLED;
 	auto telemetryReason = SnaccTelemetryData::Reason::UNKNOWN_FAILURE;
@@ -1416,7 +1416,7 @@ long SnaccROSEBase::SendEvent(SNACC::ROSEInvoke* pinvoke, const char* szOperatio
 	if (!pCtx)
 	{
 		SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, pinvoke, szResolvedOperationName ? szResolvedOperationName : szOperationName);
-		pCtx = SnaccInvokeContext::Create(init);
+		pCtx = CreateInvokeContext(init);
 	}
 	auto& ctx = *pCtx;
 	size_t stRequestData = 0;
@@ -1521,7 +1521,7 @@ long SnaccROSEBase::SendInvoke(SNACC::ROSEInvoke* pinvoke, SNACC::AsnType* resul
 	if (!pCtx)
 	{
 		SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, pinvoke, szResolvedOperationName ? szResolvedOperationName : szOperationName);
-		pCtx = SnaccInvokeContext::Create(init);
+		pCtx = CreateInvokeContext(init);
 	}
 	auto& ctx = *pCtx;
 

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "7.0.4"
-#define VERSION_RC 7, 0, 4
-#define RELDATE "29.06.2026"
+#define VERSION "7.0.6"
+#define VERSION_RC 7, 0, 6
+#define RELDATE "03.07.2026"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Summary

- Fix `SnaccROSEBase` to call `CreateInvokeContext()` instead of `SnaccInvokeContext::Create()` in `OnInvokeMessage`, `SendEvent`, and `SendInvoke`.
- Transport subclasses (e.g. UCServer `ENetCtiTransport`, `MeetingConnectionBase`) override `CreateInvokeContext()` to supply custom invoke context types; the static factory bypassed those overrides.
- Bump snacclib7 to **7.0.6** (release date **03.07.2026**).

## Test plan

- [ ] Build snacclib7 / esnacc on CI
- [ ] Verify UCServer and alllibs compile against updated snacclib7 with custom invoke contexts (`ENetCtiCustomInvokeContext`, `MeetingConnectionInvokeContext`)