### PR TITLE
UCAAS-1333: optional timeout on CreateOutboundInvokeContext (7.0.9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,8 @@ Other backends (C, C#, Java, Kotlin, Swift, Delphi, JavaScript, IDL, JSDoc, Open
 
 | Doc | Use when |
 |-----|----------|
-| [ReadMe.md](ReadMe.md) | Build instructions, repo overview, supported targets |
+| [ReadMe.md](ReadMe.md) | Repository overview and quick start |
+| [docs/build.md](docs/build.md) | CMake and IDE build instructions |
 | [FAQ.md](FAQ.md) | Compiler background, licensing, capability questions |
 | [samples/readme.md](samples/readme.md) | Running or updating samples |
 | [samples/ts-microservice/readme.md](samples/ts-microservice/readme.md) | TypeScript microservice layout and verification flow |
@@ -75,7 +76,7 @@ Other backends (C, C#, Java, Kotlin, Swift, Delphi, JavaScript, IDL, JSDoc, Open
 | Change TypeScript generation | `ReadMe.md`, `compiler/back-ends/ts-gen/` | `samples/ts-microservice/` |
 | Change C++ generation or runtime | `ReadMe.md`, `cpp-lib/tests/runtime_correctness_notes.md` | `compiler/back-ends/c++-gen/`, `cpp-lib/` |
 | Add/fix a sample | `samples/readme.md` | The specific sample subdirectory |
-| Build or CI for the compiler | `ReadMe.md` | `compiler/CMakeLists.txt`, root `CMakeLists.txt` |
+| Build or CI for the compiler | [docs/build.md](docs/build.md) | `compiler/CMakeLists.txt`, root `CMakeLists.txt` |
 | OpenAPI / JSDoc output | `FAQ.md` | `compiler/back-ends/openapi-gen/`, `compiler/back-ends/jsondoc-gen/` |
 
 ## Build quick reference
@@ -89,7 +90,7 @@ cmake ..
 cmake --build .
 ```
 
-Requirements and IDE-specific steps are in [ReadMe.md](ReadMe.md). CMake minimum version: 3.20.
+Requirements and IDE-specific steps are in [docs/build.md](docs/build.md). CMake minimum version: 3.20.
 
 ## Working conventions
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,151 +1,100 @@
-# estos Enhanced Sample Neufeld ASN C Compiler
-This is the estos enhanced sample neufeld asn c compiler. 
-It is an functional enriched fork of the original enhanced sample neufeld asn c compiler offering:
-* Documented source code, based on the documentation from the asn1 source files
-* Creating documentation based on the documentation from the asn1 source files
-* Additional supported target languages
-  * C
-    * Structure definitions
-    * BER encoder/decoders
-  * Typescript (main maintained language)
-    * Structure definitions
-    * JSON and BER encoder/decoders
-    * ROSE client implementation (complete stubs) for node and the browser side
-    * ROSE server implementation (complete stubs)
-  * C++ (main maintained language)
-    * Structure definitions
-    * JSON and BER encoder/decoders
-    * ROSE client/server implementation (complete stubs)
-  * C#
-    * Structure definitions
-  * Delphi
-    * Structure definitions
-  * JAVA
-    * Structure definitions
-  * Kotlin
-    * Structure definitions
-  * JavaScript JSON
-    * Structure definitions
-  * JavaScript ES6
-    * Structure definitions
-  * SWIFT
-    * Structure definitions
-  * IDL
-    * Interface definitions
-  * JSDOC
-    * JSON formatted Documentation generated based on the documentation inside the asn1 files
-  * OpenApi
-    * OpenApi JSON Documentation generated based on the documentation inside the asn1 files
-    * Should be used with our swagger-ui project https://github.com/ESTOS/esnacc-openapi-sdk
-      * Example can be found [here](samples/ts-microservice/openapi)  
+# esnacc
 
-# Functionality
-Based on asn1 files the compiler transcodes the information into matching representations in different languages. Different target languages have different feature sets implemented. The currently two main languages are typescript and c++ which offer the most features.
-Those two languages offer JSON and BER encoding for the transport layer, a complete ROSE (Remote Operations Service Element) implementation for both sides, the server and the client side.
-Other languages just offer to get created structures which need to get serialized / deserialized in JSON with other functions of the language.
+**ASN.1 → typed stubs, encoders, and ROSE runtime** — primary targets **TypeScript** and **C++**, plus many additional language backends.
 
-# Getting started
-You need to compile the compiler or use a precompiled version of it.
-The samples folder offers examples on the usage for the different supported languages. These folders show some sample asn1 files, the command line and the expected output of the compiler.
-See [samples/readme.md](samples/readme.md) for the current TypeScript microservice sample layout and required Node/pnpm setup.
+[estos](https://www.estos.de) enhanced SNACC: parse ASN.1 modules, generate client/server stubs (where supported), and link against runtimes that handle BER/JSON encoding, ROSE invoke flow, telemetry, and async completion.
 
-# Building the compiler
-## Prerequesites to compile the compiler
-* Have cmake installed 
-  * https://cmake.org
-  * at least V3.20
-  * available in the path
-  
-## Command line
-* From the root path of the repo, create a directory where all intermemdiate and build files will be written to
-  ```shell
-  mkdir build
-  ```
-* Navigate into this directory and generate the needed build files with cmake
-  ```shell
-  cd build
-  cmake ..
-    ```
-* Build the compiler and libraries  
-  ```shell
-  cmake --build .
-  ```
+## The three blocks
 
-You may use the following cmake commandline variables to parameterize the output:
+```
+  .asn1 modules          esnacc compiler          your application
+       │                       │                        ▲
+       └──────►  generated stubs (Invoke_ / OnInvoke_) ─┤
+       └──────►  runtime library (cpp-lib / TS glue) ──┘
+```
 
-* __CPP_LIBRARY_OUTPUT_PATH__
-  * the output path where debug and release builds of the cpp library will be written to
-  * by default the libraries are written to /output/libx64 for x64 and /output/lib for x86
+| Block | What it is | Where |
+|-------|------------|--------|
+| **Compiler** | Parses ASN.1, emits types and ROSE stubs | `compiler/`, `output/bin/esnacc` |
+| **Generated output** | Types, encoders, ROSE stubs, or API docs — per target | Your build output directory |
+| **Runtime** | Transport hooks, invoke context, encode/decode, telemetry | `cpp-lib/`, TS glue under `compiler/back-ends/ts-gen/` |
 
-* __CPP_LIBRARY_OUTPUT_NAME__
-  - the name of the library (e.g. if you want to specify a version like snacclib_1_2)
-  - by default the name is "esnacc_cpp_lib"
-  - a "d" is always added for debug builds
+## Supported targets
 
-* __COMPILER_OUTPUT_PATH__
-  - the output path where debug and release builds of the compiler will be written to
-  - by default the compiler is written to /output/bin
+The compiler can emit several kinds of output from the same ASN.1 modules. Feature depth varies by backend; **C++** and **TypeScript** are the fully maintained ROSE stacks.
 
-* __COMPILER_OUTPUT_NAME__
-  - the name of the compiler (e.g. if you want to specify a version like esnacc_1_2)
-  - by default the name is "esnacc"
-  - the .exe for windows is automatically added
+| Target | Generated output |
+|--------|------------------|
+| **C** | Structure definitions; BER encoder/decoders |
+| **C++** | Structure definitions; JSON and BER encoder/decoders; ROSE client/server stubs |
+| **TypeScript** | Structure definitions; JSON and BER encoder/decoders; ROSE client stubs (Node + browser) and server stubs |
+| **C#** | Structure definitions |
+| **Delphi** | Structure definitions |
+| **Java** | Structure definitions |
+| **Kotlin** | Structure definitions |
+| **JavaScript (JSON)** | Structure definitions |
+| **JavaScript (ES6)** | Structure definitions |
+| **Swift** | Structure definitions |
+| **IDL** | Interface definitions |
+| **JSDoc** | JSON documentation from ASN.1 comments |
+| **OpenAPI** | OpenAPI JSON from ASN.1 comments — use with [esnacc-openapi-sdk](https://github.com/ESTOS/esnacc-openapi-sdk) ([sample](samples/ts-microservice/openapi)) |
 
-* __COMPILER_OUTPUT_NAME_DEBUG__
-  - the name of the compiler (e.g. if you want to specify a version like esnacc_1_2d)
-  - by default the name is "esnaccd"
-  - the .exe for windows is automatically added
+Backends live under `compiler/back-ends/` (`c-gen`, `c++-gen`, `ts-gen`, `cs-gen`, `delphi-gen`, `java-gen`, `kotlin-gen`, `js-gen`, `jses6-gen`, `swift-gen`, `idl-gen`, `jsondoc-gen`, `openapi-gen`, …).
 
-## Visual Studio 2022
-1. Open Visual Studio
-2. Instead of "Open Project..." use "Open local folder" for Project-Selection
-3. Choose the "code" folder of the Repository - The folder that contains the root CMakeLists.txt
-4. Visual Studio will recognize the CMakeFiles.txt and starts configuring using cmake.
-   This will generate a subdirectory 'out', the equivalent of "build" from above
-5. Select "esnacc.exe" as the run configuration to debug the binary
-6. Hit F7 or CTRL-SHIFT-B to compile the compiler
+Languages without a bundled ROSE runtime typically emit structures only; serialization is handled in application code (often JSON). See [FAQ.md](FAQ.md) for background on BER vs JSON per target.
 
-## CLion
-1. Open CLion with the code directory as the project directory.
-2. Make sure, that the correct toolchain is set in the settings (Visual Studio or build-in MingW).
-3. Build
-4. For debugging, use run configuration "compiler"
+[samples/](samples/) shows command lines and expected output per language where samples exist.
 
-## Visual Studio Code
-* Have ninja installed
-  * https://github.com/ninja-build/ninja/releases
-  * at least v1.11.1
-  * available in the path
+## C++ ROSE runtime
 
-1. Open Visual Studio Code using the esnacc.code-workspace file in the code folder
-2. If not already done, install the suggested extension
-  * The extensions are advertised with the extensions.json in the .vscode sub folder
-  * C/C++
-  * C/C++ Extension Pack (brings along the C/C++ Themes)
-  * Cmake Tools
-  * CodeLLDB
-  * Clang-Format
-3. Visual Studio Code will now ask you to specify the top cmake config file which is located in the code folder CMakeLists.txt
-  * In case visual studio is not asking you use <Ctrl>+<Shift>+<P> **Cmake: Configure** -> ${workspaceFolder}././CmakeLists.txt
-4. In the bottom bar of the IDE from the left to the right you will find the settings how and what to compile / debug
-  * Check the tooltip on what option the different entry is supposed to configure as the text will be environment specific different
-  1. Element - Info about errors and warnings
-  2. Element - **Click to select the build variant** -> **Cmake: [Debug]: Ready**
-  3. Element - **Click to change the active kit** -> **Clang xx.x.x** not clang-clang-cl
-  4. Element - **Build selected target** -> builds the option on the right
-  5. Element - **Select the default build target** -> **[esnacc]**
-  * Click the build button to build the compiler
+Generated stubs call into `SnaccROSESender` / `SnaccROSEBase`. Product code typically:
 
-## macOS
-1. Make sure all development tools are installed (XCode + commandline tools)
-2. Install cmake (e.g. with homebrew)
-3. Now proceed like it is described in "Command line"
-   ```shell
-   mkdir build
-   cd build
-   cmake ..
-   cmake --build .
-   ```
+- overrides **`CreateInvokeContext()`** to supply a derived `SnaccInvokeContext`
+- uses **`CreateOutboundInvokeContext()`** for timeout / async callback setup on outbound calls
+- passes the **stub operation name** to `SendInvoke` / `SendEvent` (authoritative for send, logging, and telemetry)
 
-The Compiler will be generated in ```output/bin```
+Inbound context operation names resolve from **`operationID`** via the lookup map, not from wire `operationName`.
 
+**Spec and tests:** [cpp-lib/tests/runtime_correctness_notes.md](cpp-lib/tests/runtime_correctness_notes.md) — intended semantics for the public C++ runtime API (147 runtime tests in `cpp-lib/tests`).
+
+**Core ROSE ASN.1 module:** regenerate checked-in glue from [ROSE/SNACCROSE.asn1](ROSE/SNACCROSE.asn1) via [ROSE/makesnaccrose.bat](ROSE/makesnaccrose.bat).
+
+## TypeScript
+
+The [ts-microservice sample](samples/ts-microservice/readme.md) is the reference layout: Node server (REST + WebSocket), browser client, and headless integration tests over shared ASN.1 interfaces.
+
+Start here: [samples/readme.md](samples/readme.md).
+
+## Quick start
+
+```shell
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+Run C++ runtime tests (after build):
+
+```shell
+cmake --build . --config Release --target cpp-lib-sample-runtime-tests
+./cpp-lib/tests/Release/cpp-lib-sample-runtime-tests    # path may vary by platform
+```
+
+Full build options and IDE workflows: **[docs/build.md](docs/build.md)**.
+
+## Documentation
+
+| Topic | Document |
+|-------|----------|
+| Repository map and agent routing | [AGENTS.md](AGENTS.md) |
+| Build (CMake, VS, CLion, VS Code, macOS) | [docs/build.md](docs/build.md) |
+| C++ runtime semantics | [cpp-lib/tests/runtime_correctness_notes.md](cpp-lib/tests/runtime_correctness_notes.md) |
+| Samples and integration tests | [samples/readme.md](samples/readme.md) |
+| Background, licensing, capabilities | [FAQ.md](FAQ.md) |
+| OpenAPI + Swagger UI | [esnacc-openapi-sdk](https://github.com/ESTOS/esnacc-openapi-sdk) · [sample](samples/ts-microservice/openapi) |
+
+## Releases
+
+Pre-release betas are published on [GitHub Releases](https://github.com/ESTOS/esnacc/releases). Tags follow `7.0/<version>.beta.<n>`.
+
+Use a tagged release or build from source, then regenerate stubs when upgrading the compiler or runtime.

--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace SNACC
@@ -234,10 +235,15 @@ public:
 	virtual std::shared_ptr<SnaccInvokeContext> CreateInvokeContext(const SnaccInvokeContextInit& init) = 0;
 
 	/*! Pre-configures an outbound invoke context (timeout, async callback, product fields).
-		Delegates to virtual CreateInvokeContext() so product code can supply a derived type. */
-	std::shared_ptr<SnaccInvokeContext> CreateOutboundInvokeContext()
+		Delegates to virtual CreateInvokeContext() so product code can supply a derived type.
+		When @p invokeTimeoutMs is set, applies SetInvokeTimeout() on the new context; omit it to
+		leave the connection default (-1). Value 0 selects fire-and-forget dispatch. */
+	std::shared_ptr<SnaccInvokeContext> CreateOutboundInvokeContext(std::optional<unsigned int> invokeTimeoutMs = std::nullopt)
 	{
-		return CreateInvokeContext(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND));
+		auto pCtx = CreateInvokeContext(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND));
+		if (invokeTimeoutMs.has_value())
+			pCtx->SetInvokeTimeout(static_cast<int>(*invokeTimeoutMs));
+		return pCtx;
 	}
 
 	/*! Increment invoke counter and return InvokeID */

--- a/cpp-lib/tests/invoke_context_tests.cpp
+++ b/cpp-lib/tests/invoke_context_tests.cpp
@@ -709,6 +709,23 @@ namespace sample_runtime_tests
 		AssertOrphanRejectDoesNotBreakPendingInvoke(TransportEncoding::JSON);
 	}
 
+	TEST_F(InvokeContextRuntimeTest, CreateOutboundInvokeContextOptionalTimeout)
+	{
+		InitializeEndpoints(TransportEncoding::BER);
+
+		const auto pDefault = m_client.CreateOutboundInvokeContext();
+		ASSERT_TRUE(pDefault);
+		EXPECT_EQ(-1, pDefault->InvokeTimeout());
+
+		const auto pFireAndForget = m_client.CreateOutboundInvokeContext(0u);
+		ASSERT_TRUE(pFireAndForget);
+		EXPECT_EQ(0, pFireAndForget->InvokeTimeout());
+
+		const auto pExplicit = m_client.CreateOutboundInvokeContext(250u);
+		ASSERT_TRUE(pExplicit);
+		EXPECT_EQ(250, pExplicit->InvokeTimeout());
+	}
+
 	TEST(InvokeContextInitTest, OutboundInitStoresExplicitOperationName)
 	{
 		const SnaccInvokeContextInit init(SnaccInvokeDirection::OUTBOUND, nullptr, "asnDeprecatedMethod");

--- a/cpp-lib/tests/runtime_correctness_notes.md
+++ b/cpp-lib/tests/runtime_correctness_notes.md
@@ -392,7 +392,9 @@ Each helper detaches borrowed pointers in its destructor.
 1. **Outbound invokes and events:** the generated stub literal passed to
    `SendInvoke` / `SendEvent` is the authoritative operation name for telemetry,
    logging, and transport encoding. Normal outbound contexts use
-   `CreateOutboundInvokeContext()` (no name on the context). Generated deprecated
+   `CreateOutboundInvokeContext()` (no name on the context). Pass
+   `std::optional<unsigned int>` to set invoke timeout in the same call; omit it for the
+   connection default (-1). Generated deprecated
    outbound stubs default to `CreateInvokeContext(SnaccInvokeContextInit(OUTBOUND,
    invoke, operationName))` so `SNACCDeprecated::DeprecatedASN1Method` can read
    `OperationName()` on the context.

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,63 @@
+# Building esnacc
+
+This guide covers compiling the compiler and C++ runtime from source. For a short overview of the repository, see [ReadMe.md](../ReadMe.md).
+
+## Prerequisites
+
+- [CMake](https://cmake.org) 3.20 or newer, available on `PATH`
+
+## Command line
+
+From the repository root:
+
+```shell
+mkdir build
+cd build
+cmake ..
+cmake --build .
+```
+
+Outputs (defaults):
+
+| Artifact | Location |
+|----------|----------|
+| Compiler (`esnacc` / `esnaccd`) | `output/bin/` |
+| C++ library (`esnacc_cpp_lib`) | `output/libx64/` (x64) or `output/lib/` (x86) |
+
+### CMake variables
+
+| Variable | Purpose |
+|----------|---------|
+| `CPP_LIBRARY_OUTPUT_PATH` | Output directory for the C++ library |
+| `CPP_LIBRARY_OUTPUT_NAME` | Library base name (debug builds append `d`) |
+| `COMPILER_OUTPUT_PATH` | Output directory for the compiler executable |
+| `COMPILER_OUTPUT_NAME` | Release compiler name (default `esnacc`) |
+| `COMPILER_OUTPUT_NAME_DEBUG` | Debug compiler name (default `esnaccd`) |
+
+## Visual Studio 2022
+
+1. Open Visual Studio and choose **Open a local folder** (not Open Project).
+2. Select the repository root (contains the top-level `CMakeLists.txt`).
+3. Let CMake configure (creates an `out/` directory).
+4. Set the startup item to `esnacc.exe`.
+5. Build with **F7** or **Ctrl+Shift+B**.
+
+## CLion
+
+1. Open the repository root as the project.
+2. Select the toolchain (Visual Studio or MinGW).
+3. Build the `compiler` run configuration.
+
+## Visual Studio Code
+
+Prerequisite: [Ninja](https://github.com/ninja-build/ninja/releases) 1.11.1+ on `PATH`.
+
+1. Open `esnacc.code-workspace`.
+2. Install suggested extensions (C/C++, CMake Tools, CodeLLDB, Clang-Format).
+3. Configure CMake with the root `CMakeLists.txt`.
+4. Select the `esnacc` build target and build.
+
+## macOS
+
+1. Install Xcode command-line tools and CMake (e.g. via Homebrew).
+2. Follow the command-line steps above.

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "7.0.8"
-#define VERSION_RC 7, 0, 8
-#define RELDATE "13.07.2026"
+#define VERSION "7.0.9"
+#define VERSION_RC 7, 0, 9
+#define RELDATE "16.07.2026"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Summary

- Add optional `invokeTimeoutMs` to `SnaccROSESender::CreateOutboundInvokeContext()` so callers can set fire-and-forget (`0`), explicit timeouts, or leave the connection default (`-1`).
- Bump release version to **7.0.9** (16.07.2026).
- Add cpp-lib coverage for the new outbound context timeout behavior.
- Modernize top-level README and move build instructions to `docs/build.md`.

## Changes

- `SnaccROSEInterfaces.h`: `CreateOutboundInvokeContext(std::optional<unsigned int> invokeTimeoutMs = std::nullopt)`
- `invoke_context_tests.cpp`: `CreateOutboundInvokeContextOptionalTimeout` test
- `version.h`: `7.0.8` → `7.0.9`
- Docs: `ReadMe.md`, `docs/build.md`, `AGENTS.md`

## Test plan

- [x] `cpp-lib-sample-runtime-tests` — invoke context tests including optional timeout case
- [ ] ProCall consumer branch `feature/UCAAS-1333-make-use-of-esnacc7` builds against this release
- [ ] ProCall async client branch `feature/UCAAS-1440-support-async-calls` builds against this release