### PR TITLE
UCAAS-1445: safe telemetry invoke context retention (7.0.10)

### DIFF
--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -154,16 +154,17 @@ class SnaccInvokeContext
 {
 public:
 	static std::shared_ptr<SnaccInvokeContext> Create(const SnaccInvokeContextInit& init);
+
+	/*! Builds the invoke-context snapshot stored on @ref SnaccTelemetryData.
+		Calls @ref Clone(), clears lib-owned async decode borrows on the clone, then @ref PrepareForTelemetry(). */
+	virtual std::shared_ptr<SnaccInvokeContext> CloneForTelemetryRetention() const final;
+
 	virtual std::shared_ptr<SnaccInvokeContext> Clone() const;
 
 	SnaccInvokeContext& operator=(const SnaccInvokeContext&) = delete;
 	SnaccInvokeContext(SnaccInvokeContext&&) = delete;
 	SnaccInvokeContext& operator=(SnaccInvokeContext&&) = delete;
 	virtual ~SnaccInvokeContext();
-
-	// Called immediately before the context is transferred into telemetry retention.
-	// Override if derived types keep borrowed data that must be detached or copied.
-	virtual void PrepareForTelemetry();
 
 	// Meaning in OnInvoke_: Authentication Header from the ROSE Invoke (Pointer to the object in the invoke)
 	// Meaning in Invoke_: Authentication Header that is dispatched along with the invoke (create it with new, cleanup is done inside)
@@ -219,6 +220,14 @@ protected:
 	explicit SnaccInvokeContext(const SnaccInvokeContextInit& init);
 	// Allows derived context types to copy the base invoke-context state into a richer concrete type.
 	SnaccInvokeContext(const SnaccInvokeContext& other);
+
+	/*! Called on a telemetry-retained clone after @ref CloneForTelemetryRetention() copied dispatch state.
+		Dispatch often stores non-owning raw pointers (stub @c ROSEInvoke, transport, session objects)
+		that are only valid while snacclib is still inside the invoke scope. Before the clone is
+		stored on @ref SnaccTelemetryData, override this to copy any needed fields into owned members,
+		then clear those pointers so telemetry cannot outlive the stub stack frame. The live dispatch
+		context is not modified. Lib-owned async result/error buffers are already cleared before this hook. */
+	virtual void PrepareForTelemetry();
 
 	std::string m_strOperationName;
 	int m_iInvokeTimeout{-1};

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -271,6 +271,20 @@ std::shared_ptr<SnaccInvokeContext> SnaccInvokeContext::Clone() const
 	return std::shared_ptr<SnaccInvokeContext>(new SnaccInvokeContext(*this));
 }
 
+std::shared_ptr<SnaccInvokeContext> SnaccInvokeContext::CloneForTelemetryRetention() const
+{
+	auto retained = Clone();
+	retained->m_asyncCallback = {};
+	retained->m_pAsyncResult = nullptr;
+	retained->m_pAsyncError = nullptr;
+	retained->PrepareForTelemetry();
+	return retained;
+}
+
+void SnaccInvokeContext::PrepareForTelemetry()
+{
+}
+
 SnaccScopedInvokeMessage::SnaccScopedInvokeMessage(long invokeID, unsigned int uiOperationID, SNACC::AsnType* pArgument)
 	: m_pInvoke(new SNACC::ROSEInvoke())
 {
@@ -321,10 +335,6 @@ SnaccInvokeContext::~SnaccInvokeContext()
 		delete m_pRejectAuth;
 		m_pRejectAuth = nullptr;
 	}
-}
-
-void SnaccInvokeContext::PrepareForTelemetry()
-{
 }
 
 void SnaccInvokeContext::SetInvokeTimeout(int iTimeoutMs)

--- a/cpp-lib/src/SnaccTelemetry.cpp
+++ b/cpp-lib/src/SnaccTelemetry.cpp
@@ -130,10 +130,7 @@ void SnaccTelemetryData::finalize(Outcome outcome, Stage stage, Reason reason, s
 
 	std::shared_ptr<SnaccInvokeContext> pTelemetryctx;
 	if (pctx)
-	{
-		pTelemetryctx = pctx->Clone();
-		pTelemetryctx->PrepareForTelemetry();
-	}
+		pTelemetryctx = pctx->CloneForTelemetryRetention();
 
 	m_Duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_ChronoCreated);
 	m_Outcome = outcome;

--- a/cpp-lib/tests/telemetry_tests.cpp
+++ b/cpp-lib/tests/telemetry_tests.cpp
@@ -52,6 +52,15 @@ void ExpectOutboundWaitTelemetry(const SnaccTelemetryData* pTelemetry, const Sna
 		EXPECT_GT(pTelemetry->m_stResponseData.value(), 0u);
 	}
 	EXPECT_GE(pTelemetry->m_Duration.count(), 0);
+	if (pTelemetry->m_pctx)
+		ExpectTelemetryInvokeContextLibBorrowsCleared(*pTelemetry->m_pctx);
+}
+
+void ExpectTelemetryInvokeContextLibBorrowsCleared(const SnaccInvokeContext& ctx)
+{
+	EXPECT_FALSE(ctx.HasAsyncCompletion());
+	EXPECT_EQ(nullptr, ctx.AsyncResultBuffer());
+	EXPECT_EQ(nullptr, ctx.AsyncErrorBuffer());
 }
 
 long SendAsyncGetSettings(RuntimeEndpoint& client, AsyncInvokeLatch& latch, AsnGetSettingsResult& result, AsnRequestError& error, int timeoutMs)
@@ -265,7 +274,7 @@ protected:
 	}
 
 	// Verifies that outbound telemetry receives a cloned custom context and that
-	// PrepareForTelemetry only touches the retained clone.
+	// retention cleanup only touches the retained clone.
 	void AssertCustomContextIsClonedAndPrepared(const TransportEncoding encoding)
 	{
 		InitializeEndpoints(encoding);
@@ -293,6 +302,9 @@ protected:
 		EXPECT_EQ("client-session", pSessionCtx->m_strInvokeSessionId);
 		EXPECT_TRUE(pSessionCtx->WasPreparedForTelemetry());
 		EXPECT_EQ("prepared:custom", pSessionCtx->TelemetryNote());
+		ExpectTelemetryInvokeContextLibBorrowsCleared(*pSessionCtx);
+		EXPECT_EQ(nullptr, pSessionCtx->DispatchBorrowForTest());
+		EXPECT_NE(nullptr, dynamic_cast<SessionInvokeContext*>(pCtx.get())->DispatchBorrowForTest());
 	}
 
 	// Verifies that outbound transport failures are reported at OUTBOUND_SEND.

--- a/cpp-lib/tests/telemetry_tests.cpp
+++ b/cpp-lib/tests/telemetry_tests.cpp
@@ -32,6 +32,13 @@ const SnaccTelemetryData* FindOutboundWaitTelemetry(const std::vector<std::share
 	return FindTelemetry(entries, SnaccTelemetryData::Direction::OUTBOUND, SnaccTelemetryData::Stage::OUTBOUND_WAIT, reason);
 }
 
+void ExpectTelemetryInvokeContextLibBorrowsCleared(const SnaccInvokeContext& ctx)
+{
+	EXPECT_FALSE(ctx.HasAsyncCompletion());
+	EXPECT_EQ(nullptr, ctx.AsyncResultBuffer());
+	EXPECT_EQ(nullptr, ctx.AsyncErrorBuffer());
+}
+
 void ExpectOutboundWaitTelemetry(const SnaccTelemetryData* pTelemetry, const SnaccTelemetryData::Outcome outcome, const SnaccTelemetryData::Reason reason, const std::optional<long> roseResult,
 	const bool bExpectRequestData, const bool bExpectResponseData)
 {
@@ -54,13 +61,6 @@ void ExpectOutboundWaitTelemetry(const SnaccTelemetryData* pTelemetry, const Sna
 	EXPECT_GE(pTelemetry->m_Duration.count(), 0);
 	if (pTelemetry->m_pctx)
 		ExpectTelemetryInvokeContextLibBorrowsCleared(*pTelemetry->m_pctx);
-}
-
-void ExpectTelemetryInvokeContextLibBorrowsCleared(const SnaccInvokeContext& ctx)
-{
-	EXPECT_FALSE(ctx.HasAsyncCompletion());
-	EXPECT_EQ(nullptr, ctx.AsyncResultBuffer());
-	EXPECT_EQ(nullptr, ctx.AsyncErrorBuffer());
 }
 
 long SendAsyncGetSettings(RuntimeEndpoint& client, AsyncInvokeLatch& latch, AsnGetSettingsResult& result, AsnRequestError& error, int timeoutMs)

--- a/cpp-lib/tests/test_support/sample_runtime_harness.h
+++ b/cpp-lib/tests/test_support/sample_runtime_harness.h
@@ -260,9 +260,10 @@ public:
 		return std::shared_ptr<SnaccInvokeContext>(new SessionInvokeContext(*this));
 	}
 
-	// Placeholder hook for future telemetry tests that may need to detach data.
+	// Records that PrepareForTelemetry() ran on the telemetry-retained clone.
 	void PrepareForTelemetry() override
 	{
+		m_pDispatchBorrow = nullptr;
 		m_bPreparedForTelemetry = true;
 		if (!m_strTelemetryNote.empty())
 			m_strTelemetryNote = "prepared:" + m_strTelemetryNote;
@@ -280,10 +281,16 @@ public:
 		return m_strTelemetryNote;
 	}
 
-	// Returns whether PrepareForTelemetry() has already run on this concrete instance.
+	// Returns whether retention cleanup has already run on this concrete instance.
 	bool WasPreparedForTelemetry() const
 	{
 		return m_bPreparedForTelemetry;
+	}
+
+	// Simulates a product-owned dispatch borrow; cleared in PrepareForTelemetry() on the telemetry clone.
+	const SNACC::ROSEInvoke* DispatchBorrowForTest() const
+	{
+		return m_pDispatchBorrow;
 	}
 
 	const std::string m_strLocalSessionId; // session id of the endpoint creating the context
@@ -294,7 +301,8 @@ private:
 	SessionInvokeContext(const SnaccInvokeContextInit& init, const std::string& localSessionId)
 		: SnaccInvokeContext(init),
 		  m_strLocalSessionId(localSessionId),
-		  m_strInvokeSessionId(GetInvokeSessionId(init.m_pInvoke))
+		  m_strInvokeSessionId(GetInvokeSessionId(init.m_pInvoke)),
+		  m_pDispatchBorrow(init.m_pInvoke)
 	{
 	}
 
@@ -304,12 +312,14 @@ private:
 		  m_strLocalSessionId(other.m_strLocalSessionId),
 		  m_strInvokeSessionId(other.m_strInvokeSessionId),
 		  m_bPreparedForTelemetry(other.m_bPreparedForTelemetry),
-		  m_strTelemetryNote(other.m_strTelemetryNote)
+		  m_strTelemetryNote(other.m_strTelemetryNote),
+		  m_pDispatchBorrow(other.m_pDispatchBorrow)
 	{
 	}
 
 	bool m_bPreparedForTelemetry = false; // indicates whether the telemetry clone was normalized for retention
 	std::string m_strTelemetryNote;       // extra test data used to verify clone and prepare semantics
+	const SNACC::ROSEInvoke* m_pDispatchBorrow = nullptr;
 };
 
 // Copies invoke-context fields while the runtime reference is still alive.

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "7.0.9"
-#define VERSION_RC 7, 0, 9
-#define RELDATE "16.07.2026"
+#define VERSION "7.0.10"
+#define VERSION_RC 7, 0, 10
+#define RELDATE "24.07.2026"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Summary
- Add `CloneForTelemetryRetention()` on `SnaccInvokeContext`: clones via product `Clone()`, clears lib async borrows on the retained copy, then calls protected `PrepareForTelemetry()` for product hooks.
- Route `SnaccTelemetryData` finalization through the new path instead of retaining a live dispatch context.
- Extend telemetry tests to assert lib borrows are cleared on retained contexts; exercise product `PrepareForTelemetry` in the sample harness.
- Bump snacclib to **7.0.10** (release **24.07.2026**).

## Consumer follow-up
ProCall UCServer should override `PrepareForTelemetry()` on `ENetCtiCustomInvokeContext` (see related GitLab branch `feature/UCAAS-1445-telemetry-invoke-context`).

## Test plan
- [ ] Build snacclib7 / esnacc7 on CI
- [ ] Run `telemetry_tests` (and full cpp-lib test target if available locally)
- [ ] Regenerate a small ASN stub and confirm header shows V7.0.10 / 24.07.2026