### PR TITLE
BUILDSYS-637/638: esnacc 7.0.13 — drop versionfile, canonical @deprecated successors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,7 +53,6 @@
                 "-RTS_CLIENT_NODE",
                 "-node:24",
                 "-comments",
-                "-versionfile",
                 "*.asn1"
             ],
             "cwd": "${workspaceFolder}/samples/interface",

--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -4584,16 +4584,16 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	fprintf(hdr, "\t%s(SnaccROSESender* pBase);\n", m->ROSEClassName);
 	fprintf(src, "%s::%s(SnaccROSESender* pBase) : SnaccROSEComponent(pBase)\n", m->ROSEClassName, m->ROSEClassName);
 	fprintf(src, "{\n");
-	fprintf(src, "\tif (pBase)\n");
-	fprintf(src, "\t\tRegisterOperations(pBase);\n");
+	fprintf(src, "\tif (m_pSB)\n");
+	fprintf(src, "\t\tRegisterOperations();\n");
 	fprintf(src, "}\n\n");
 
 	// Function for triggering the registration of all Operations (name/id)
 	fprintf(hdr, "\t// Registers all known operations on the ROSE stub instance\n");
-	fprintf(hdr, "\tstatic void RegisterOperations(SnaccROSESender* pSender);\n");
-	fprintf(src, "void %s::RegisterOperations(SnaccROSESender* pSender)\n", m->ROSEClassName);
+	fprintf(hdr, "\tvoid RegisterOperations();\n");
+	fprintf(src, "void %s::RegisterOperations()\n", m->ROSEClassName);
 	fprintf(src, "{\n");
-	fprintf(src, "\tif (!pSender)\n");
+	fprintf(src, "\tif (!m_pSB)\n");
 	fprintf(src, "\t\treturn;\n");
 	if (gMajorInterfaceVersion >= 0)
 	{
@@ -4601,7 +4601,7 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 		char* szNumericDate = ConvertUnixTimeToNumericDate(lPatchVersion);
 		if (szNumericDate)
 		{
-			fprintf(src, "\tSnaccRoseRegisterModuleVersionOnSender(pSender, \"%s\", \"%i.0.%s\");\n", m->moduleName, gMajorInterfaceVersion, szNumericDate);
+			fprintf(src, "\tRegisterModuleVersion(\"%s\", \"%i.0.%s\");\n", m->moduleName, gMajorInterfaceVersion, szNumericDate);
 			free(szNumericDate);
 		}
 	}
@@ -4609,11 +4609,21 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	{
 		if (IsDeprecatedNoOutputOperation(m, vd->definedName))
 			continue;
-		if (PrintROSEOperationRegistration(src, r, m, vd, "pSender") && !iFirstIIDFound)
+		if (PrintROSEOperationRegistration(src, r, m, vd) && !iFirstIIDFound)
 		{
 			iFirstIIDFound = 1;
 			fprintf(hdr, "\tstatic const int m_iid = %d;\n", vd->value->basicValue->a.integer);
 		}
+	}
+
+	if (iFirstIIDFound)
+	{
+		fprintf(hdr, "protected:\n");
+		fprintf(hdr, "\tvoid RegisterOperation(unsigned int uiOpID, const char* szOpName, bool bIsEvent = false, unsigned long long ullAddedUnix = 0, unsigned long long ullDeprecatedUnix = 0)\n");
+		fprintf(hdr, "\t{\n");
+		fprintf(hdr, "\t\tSnaccROSEComponent::RegisterOperation(uiOpID, szOpName, m_iid, \"%s\", bIsEvent, ullAddedUnix, ullDeprecatedUnix);\n", m->moduleName);
+		fprintf(hdr, "\t}\n\n");
+		fprintf(hdr, "public:\n");
 	}
 
 	fprintf(src, "}\n\n");

--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -4583,28 +4583,37 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	// Constructor
 	fprintf(hdr, "\t%s(SnaccROSESender* pBase);\n", m->ROSEClassName);
 	fprintf(src, "%s::%s(SnaccROSESender* pBase) : SnaccROSEComponent(pBase)\n", m->ROSEClassName, m->ROSEClassName);
-	fprintf(src, "{\n}\n\n");
+	fprintf(src, "{\n");
+	fprintf(src, "\tif (pBase)\n");
+	fprintf(src, "\t\tRegisterOperations(pBase);\n");
+	fprintf(src, "}\n\n");
 
 	// Function for triggering the registration of all Operations (name/id)
-	fprintf(hdr, "\t// Function Registers all known operations in SnaccRoseOperationLookup\n");
-	fprintf(hdr, "\tstatic void RegisterOperations();\n");
-	fprintf(src, "void %s::RegisterOperations()\n", m->ROSEClassName);
+	fprintf(hdr, "\t// Registers all known operations on the ROSE stub instance\n");
+	fprintf(hdr, "\tstatic void RegisterOperations(SnaccROSESender* pSender);\n");
+	fprintf(src, "void %s::RegisterOperations(SnaccROSESender* pSender)\n", m->ROSEClassName);
 	fprintf(src, "{\n");
+	fprintf(src, "\tif (!pSender)\n");
+	fprintf(src, "\t\treturn;\n");
+	if (gMajorInterfaceVersion >= 0)
+	{
+		long long lPatchVersion = GetModulePatchVersion(m->moduleName);
+		char* szNumericDate = ConvertUnixTimeToNumericDate(lPatchVersion);
+		if (szNumericDate)
+		{
+			fprintf(src, "\tSnaccRoseRegisterModuleVersionOnSender(pSender, \"%s\", \"%i.0.%s\");\n", m->moduleName, gMajorInterfaceVersion, szNumericDate);
+			free(szNumericDate);
+		}
+	}
 	FOR_EACH_LIST_ELMT(vd, m->valueDefs)
 	{
 		if (IsDeprecatedNoOutputOperation(m, vd->definedName))
 			continue;
-		if (PrintROSEOperationRegistration(src, r, vd) && !iFirstIIDFound)
+		if (PrintROSEOperationRegistration(src, r, m, vd, "pSender") && !iFirstIIDFound)
 		{
 			iFirstIIDFound = 1;
 			fprintf(hdr, "\tstatic const int m_iid = %d;\n", vd->value->basicValue->a.integer);
 		}
-	}
-
-	if (gMajorInterfaceVersion >= 0)
-	{
-		long long lPatchVersion = GetModulePatchVersion(m->moduleName);
-		fprintf(src, "\tSnaccModuleVersions::addModuleVersion(\"%s\", %i, %lld);\n", m->moduleName, gMajorInterfaceVersion, lPatchVersion);
 	}
 
 	fprintf(src, "}\n\n");

--- a/compiler/back-ends/c++-gen/gen-code.h
+++ b/compiler/back-ends/c++-gen/gen-code.h
@@ -38,7 +38,7 @@ void PrintCxxValueExtern(FILE* hdr, CxxRules* r, ValueDef* v);
 char* LookupNamespace(Type* t, ModuleList* mods);
 void PrintROSEAnyCode(FILE* src, FILE* hdr, CxxRules* r, ModuleList* mods, Module* m);
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS);
-int PrintROSEOperationRegistration(FILE* src, CxxRules* r, ValueDef* v);
+int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v, const char* szSenderExpr);
 
 extern char* bVDAGlobalDLLExport;
 extern int gNO_NAMESPACE;

--- a/compiler/back-ends/c++-gen/gen-code.h
+++ b/compiler/back-ends/c++-gen/gen-code.h
@@ -38,7 +38,7 @@ void PrintCxxValueExtern(FILE* hdr, CxxRules* r, ValueDef* v);
 char* LookupNamespace(Type* t, ModuleList* mods);
 void PrintROSEAnyCode(FILE* src, FILE* hdr, CxxRules* r, ModuleList* mods, Module* m);
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS);
-int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v, const char* szSenderExpr);
+int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v);
 
 extern char* bVDAGlobalDLLExport;
 extern int gNO_NAMESPACE;

--- a/compiler/back-ends/c++-gen/gen-vals.c
+++ b/compiler/back-ends/c++-gen/gen-vals.c
@@ -76,7 +76,7 @@ void PrintCxxOidValue(FILE* f, CxxRules* r, AsnOid* oid, int parenOrQuote);
 void PrintCxxIntValue(FILE* f, CxxRules* r, AsnInt oid);
 static void PrintCxxValueDefsName(FILE* f, CxxRules* r, ValueDef* v);
 
-int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v, const char* szSenderExpr)
+int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v)
 {
 	/* just do ints */
 	if (v->value->basicValue->choiceId != BASICVALUE_INTEGER)
@@ -95,22 +95,34 @@ int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef
 		return 0;
 
 	const bool bIsEvent = pszResult == NULL;
-	long long llAddedUnix = 0;
-	long long llDeprecatedUnix = 0;
+	unsigned long long ullAddedUnix = 0;
+	unsigned long long ullDeprecatedUnix = 0;
 	asnoperationcomment comment;
 	if (GetOperationComment_UTF8(mod->moduleName, v->definedName, &comment))
 	{
-		llAddedUnix = comment.i64Added;
-		llDeprecatedUnix = comment.i64Deprecated;
+		if (comment.i64Added > 0)
+			ullAddedUnix = (unsigned long long)comment.i64Added;
+		if (comment.i64Deprecated > 0)
+			ullDeprecatedUnix = (unsigned long long)comment.i64Deprecated;
 	}
 
 	/*
 	 * put instantiation in src file
 	 */
-	fprintf(src, "\tSnaccRoseRegisterOperationOnSender(%s, ", szSenderExpr ? szSenderExpr : "nullptr");
+	fprintf(src, "\tRegisterOperation(");
 	fprintf(src, "%d, \"", v->value->basicValue->a.integer);
 	PrintCxxValueDefsName(src, r, v);
-	fprintf(src, "\", m_iid, \"%s\", %lldLL, %lldLL, %s);\n", mod->moduleName, llAddedUnix, llDeprecatedUnix, bIsEvent ? "true" : "false");
+	fprintf(src, "\"");
+	if (bIsEvent)
+	{
+		if (ullAddedUnix != 0 || ullDeprecatedUnix != 0)
+			fprintf(src, ", true, %lluULL, %lluULL", ullAddedUnix, ullDeprecatedUnix);
+		else
+			fprintf(src, ", true");
+	}
+	else if (ullAddedUnix != 0 || ullDeprecatedUnix != 0)
+		fprintf(src, ", false, %lluULL, %lluULL", ullAddedUnix, ullDeprecatedUnix);
+	fprintf(src, ");\n");
 
 	return 1;
 }

--- a/compiler/back-ends/c++-gen/gen-vals.c
+++ b/compiler/back-ends/c++-gen/gen-vals.c
@@ -64,6 +64,8 @@
 #include "../../../c-lib/include/asn-incl.h"
 #include "../../core/asn1module.h"
 #include "../str-util.h"
+#include "../structure-util.h"
+#include "../../core/asn_comments.h"
 #include "rules.h"
 
 extern char* bVDAGlobalDLLExport;
@@ -74,7 +76,7 @@ void PrintCxxOidValue(FILE* f, CxxRules* r, AsnOid* oid, int parenOrQuote);
 void PrintCxxIntValue(FILE* f, CxxRules* r, AsnInt oid);
 static void PrintCxxValueDefsName(FILE* f, CxxRules* r, ValueDef* v);
 
-int PrintROSEOperationRegistration(FILE* src, CxxRules* r, ValueDef* v)
+int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v, const char* szSenderExpr)
 {
 	/* just do ints */
 	if (v->value->basicValue->choiceId != BASICVALUE_INTEGER)
@@ -86,13 +88,29 @@ int PrintROSEOperationRegistration(FILE* src, CxxRules* r, ValueDef* v)
 	if (v->value->type->basicType->a.macroType->choiceId != MACROTYPE_ROSOPERATION)
 		return 0;
 
+	const char* pszArgument = NULL;
+	const char* pszResult = NULL;
+	const char* pszError = NULL;
+	if (!GetROSEDetails(mod, v, &pszArgument, &pszResult, &pszError, NULL, NULL, NULL, false))
+		return 0;
+
+	const bool bIsEvent = pszResult == NULL;
+	long long llAddedUnix = 0;
+	long long llDeprecatedUnix = 0;
+	asnoperationcomment comment;
+	if (GetOperationComment_UTF8(mod->moduleName, v->definedName, &comment))
+	{
+		llAddedUnix = comment.i64Added;
+		llDeprecatedUnix = comment.i64Deprecated;
+	}
+
 	/*
 	 * put instantiation in src file
 	 */
-	fprintf(src, "\tSnaccRoseOperationLookup::RegisterOperation(");
+	fprintf(src, "\tSnaccRoseRegisterOperationOnSender(%s, ", szSenderExpr ? szSenderExpr : "nullptr");
 	fprintf(src, "%d, \"", v->value->basicValue->a.integer);
 	PrintCxxValueDefsName(src, r, v);
-	fprintf(src, "\", m_iid);\n");
+	fprintf(src, "\", m_iid, \"%s\", %lldLL, %lldLL, %s);\n", mod->moduleName, llAddedUnix, llDeprecatedUnix, bIsEvent ? "true" : "false");
 
 	return 1;
 }

--- a/compiler/back-ends/c++-gen/gen-vals.h
+++ b/compiler/back-ends/c++-gen/gen-vals.h
@@ -4,6 +4,6 @@
 void PrintCxxValueDef(FILE* src, CxxRules* r, ValueDef* v);
 void PrintCxxValueExtern(FILE* hdr, CxxRules* r, ValueDef* v);
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS);
-int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v, const char* szSenderExpr);
+int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v);
 
 #endif

--- a/compiler/back-ends/c++-gen/gen-vals.h
+++ b/compiler/back-ends/c++-gen/gen-vals.h
@@ -4,6 +4,6 @@
 void PrintCxxValueDef(FILE* src, CxxRules* r, ValueDef* v);
 void PrintCxxValueExtern(FILE* hdr, CxxRules* r, ValueDef* v);
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS);
-int PrintROSEOperationRegistration(FILE* src, CxxRules* r, ValueDef* v);
+int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v, const char* szSenderExpr);
 
 #endif

--- a/compiler/back-ends/comment-util.c
+++ b/compiler/back-ends/comment-util.c
@@ -206,6 +206,8 @@ void printMemberComment(FILE* src, const Module* m, const TypeDef* td, const cha
 					if (szComment)
 						fprintf(src, " %s", szComment);
 					fprintf(src, "%s\n", szSuffix);
+					if (comment.iDeprecatedSuccessorInvalid)
+						fprintf(src, "%s @deprecated-successor-invalid%s\n", szPrefix, szSuffix);
 					free(szTime);
 				}
 				if (comment.i64Added)
@@ -335,6 +337,8 @@ bool printOperationComment(FILE* src, const Module* m, const char* szOperationNa
 					if (szComment)
 						fprintf(src, " %s", szComment);
 					fprintf(src, "\n");
+					if (comment.iDeprecatedSuccessorInvalid)
+						fprintf(src, "%s @deprecated-successor-invalid\n", szPrefix);
 					free(szTime);
 				}
 				if (comment.i64Added)
@@ -409,6 +413,8 @@ void printSequenceComment(FILE* src, const Module* m, const TypeDef* td, enum CO
 					if (szComment)
 						fprintf(src, " %s", szComment);
 					fprintf(src, "\n");
+					if (comment.iDeprecatedSuccessorInvalid)
+						fprintf(src, "%s @deprecated-successor-invalid\n", szPrefix);
 					free(szTime);
 				}
 				if (comment.i64Added)

--- a/compiler/back-ends/java-gen/gen-java-code.c
+++ b/compiler/back-ends/java-gen/gen-java-code.c
@@ -753,22 +753,6 @@ void PrintJAVACode(ModuleList* allMods)
 	 */
 	fNames = NewObjList();
 
-	if (gMajorInterfaceVersion >= 0 && genVersionFile)
-	{
-		char szFileName[_MAX_PATH] = {0};
-		strcpy_s(szFileName, _MAX_PATH - 1, gszOutputPath);
-		strcat_s(szFileName, _MAX_PATH - 1, "Asn1InterfaceVersion");
-		FILE* src = getJavaFilePointer(szFileName);
-		if (src)
-		{
-			long long lMaxPatchVersion = GetMaxModulePatchVersion();
-			fprintf(src, "public class Asn1InterfaceVersion {\n");
-			EmitAnnotatedModuleVersionFields(src, ModuleVersionEmitJavaClass, NULL, "\t", gMajorInterfaceVersion, lMaxPatchVersion);
-			fprintf(src, "}\n");
-			fclose(src);
-		}
-	}
-
 	FOR_EACH_LIST_ELMT(currMod, allMods)
 	{
 		if (ObjIsDefined(fNames, currMod->ROSESrcJAVAFileName, StrObjCmp))

--- a/compiler/back-ends/kotlin-gen/gen-kotlin-code.c
+++ b/compiler/back-ends/kotlin-gen/gen-kotlin-code.c
@@ -836,22 +836,6 @@ void PrintKotlinCode(ModuleList* allMods)
 	 */
 	fNames = NewObjList();
 
-	if (gMajorInterfaceVersion >= 0)
-	{
-		char szFileName[_MAX_PATH] = {0};
-		strcpy_s(szFileName, _MAX_PATH - 1, gszOutputPath);
-		strcat_s(szFileName, _MAX_PATH - 1, "Asn1InterfaceVersion");
-		FILE* src = getKotlinFilePointer(szFileName);
-		if (src)
-		{
-			long long lMaxPatchVersion = GetMaxModulePatchVersion();
-			fprintf(src, "object Asn1InterfaceVersion {\n");
-			EmitAnnotatedModuleVersionFields(src, ModuleVersionEmitKotlinObject, NULL, "\t", gMajorInterfaceVersion, lMaxPatchVersion);
-			fprintf(src, "}\n");
-			fclose(src);
-		}
-	}
-
 	FOR_EACH_LIST_ELMT(currMod, allMods)
 	{
 		if (ObjIsDefined(fNames, currMod->ROSESrcJAVAFileName, StrObjCmp))

--- a/compiler/back-ends/swift-gen/gen-swift-code.c
+++ b/compiler/back-ends/swift-gen/gen-swift-code.c
@@ -1409,26 +1409,6 @@ void PrintSwiftCode(ModuleList* allMods, long longJmpVal, int genTypes, int genV
 	DefinedObj* fNames;
 	int fNameConflict = FALSE;
 
-	if (gMajorInterfaceVersion >= 0 && genVersionFile)
-	{
-		FILE* versionFile = NULL;
-		char szFileName[_MAX_PATH] = {0};
-		strcpy_s(szFileName, _MAX_PATH - 1, gszOutputPath);
-		strcat_s(szFileName, _MAX_PATH - 1, "Asn1InterfaceVersion.swift");
-		if (fopen_s(&versionFile, szFileName, "wt") != 0 || versionFile == NULL)
-			perror("fopen");
-		else
-		{
-			long long lMaxPatchVersion = GetMaxModulePatchVersion();
-			fprintf(versionFile, "import Foundation\n\n");
-			fprintf(versionFile, "struct Asn1InterfaceVersion\n");
-			fprintf(versionFile, "{\n");
-			EmitAnnotatedModuleVersionFields(versionFile, ModuleVersionEmitSwiftStruct, NULL, "    ", gMajorInterfaceVersion, lMaxPatchVersion);
-			fprintf(versionFile, "}\n");
-			fclose(versionFile);
-		}
-	}
-
 	/*
 	 * Make names for each module's encoder/decoder src and hdr files
 	 * so import references can be made via include files

--- a/compiler/back-ends/ts-gen/gen-ts-code.c
+++ b/compiler/back-ends/ts-gen/gen-ts-code.c
@@ -1019,29 +1019,6 @@ void PrintTSCode(ModuleList* allMods, long longJmpVal, int genTypes, int genValu
 		FreeDefinedObjs(&fNames);
 	}
 
-	if (gMajorInterfaceVersion >= 0 && genVersionFile)
-	{
-		FILE* versionFile = NULL;
-		char* szVersionFile = MakeFileName("Asn1InterfaceVersion.ts", "");
-		if (fopen_s(&versionFile, szVersionFile, "wt") != 0 || versionFile == NULL)
-			perror("fopen");
-		else
-		{
-			fprintf(versionFile, "/*\n");
-			write_snacc_header(versionFile, " * ");
-			fprintf(versionFile, "*/\n\n");
-			fprintf(versionFile, DPRINT_DISABLE);
-			fprintf(versionFile, ESLINT_DISABLE);
-			fprintf(versionFile, "\n");
-			long long lMaxPatchVersion = GetMaxModulePatchVersion();
-			fprintf(versionFile, "export class Asn1InterfaceVersion {\n");
-			EmitAnnotatedModuleVersionFields(versionFile, ModuleVersionEmitTsClassStatic, NULL, "\t", gMajorInterfaceVersion, lMaxPatchVersion);
-			fprintf(versionFile, "}\n");
-			fclose(versionFile);
-		}
-		free(szVersionFile);
-	}
-
 	FILE* typesFile = NULL;
 	char* szTypes = MakeFileName("types.ts", "");
 	if (fopen_s(&typesFile, szTypes, "wt") != 0 || typesFile == NULL)

--- a/compiler/back-ends/ts-gen/gen-ts-combined.c
+++ b/compiler/back-ends/ts-gen/gen-ts-combined.c
@@ -59,7 +59,11 @@ void PrintTSEscaped(FILE* src, const char* szData)
 void PrintTSRootTypes(FILE* src, Module* mod, const char* szSuffix)
 {
 	fprintf(src, "// [%s]\n", __FUNCTION__);
-	fprintf(src, "export const MODULE_NAME = \"%s%s\";\n", mod->moduleName, szSuffix ? szSuffix : "");
+	// ASN.1 module identity and version belong on the base types file only (not Converter/ROSE artifacts).
+	if (szSuffix && szSuffix[0])
+		return;
+
+	fprintf(src, "export const MODULE_NAME = \"%s\";\n", mod->moduleName);
 
 	if (gMajorInterfaceVersion >= 0)
 	{

--- a/compiler/back-ends/ts-gen/gen-ts-converter.c
+++ b/compiler/back-ends/ts-gen/gen-ts-converter.c
@@ -1629,9 +1629,6 @@ void PrintTSConverterCode(FILE* src, ModuleList* mods, Module* m, long longJmpVa
 	// Includes
 	PrintTSConverterImports(src, mods, m);
 
-	// Root types
-	PrintTSRootTypes(src, m, "_Converter");
-
 	TypeDef* td;
 	FOR_EACH_LIST_ELMT(td, m->typeDefs)
 	{

--- a/compiler/back-ends/ts-gen/gen-ts-rose.c
+++ b/compiler/back-ends/ts-gen/gen-ts-rose.c
@@ -472,17 +472,38 @@ void PrintTSROSESetHandler(FILE* src, Module* m)
 	fprintf(src, "\t */\n");
 
 	fprintf(src, "\tpublic setHandler(handler: Partial<I%s_Handler>): void {\n", m->ROSEClassName);
+	if (gMajorInterfaceVersion >= 0)
+		fprintf(src, "\t\tthis.transport.registerModuleVersion(MODULE_NAME, MODULE_VERSION);\n");
 	ValueDef* vd;
 	FOR_EACH_LIST_ELMT(vd, m->valueDefs)
 	{
-		if (IsROSEValueDef(m, vd))
-			fprintf(src, "\t\tthis.transport.registerOperation(this, handler, OperationIDs.OPID_%s, \"%s\");\n", vd->definedName, vd->definedName);
-	}
+		if (!IsROSEValueDef(m, vd))
+			continue;
 
-	if (gMajorInterfaceVersion >= 0)
-	{
-		long long lPatchVersion = GetModulePatchVersion(m->moduleName);
-		fprintf(src, "\t\tthis.transport.registerModuleVersion(\"%s\", %i, %lld);\n", m->moduleName, gMajorInterfaceVersion, lPatchVersion);
+		const char* pszArgument = NULL;
+		const char* pszResult = NULL;
+		const char* pszError = NULL;
+		if (!GetROSEDetails(m, vd, &pszArgument, &pszResult, &pszError, NULL, NULL, NULL, true))
+			continue;
+
+		const bool bIsEvent = pszResult == NULL;
+		long long llAddedUnix = 0;
+		long long llDeprecatedUnix = 0;
+		asnoperationcomment comment;
+		if (GetOperationComment_UTF8(m->moduleName, vd->definedName, &comment))
+		{
+			llAddedUnix = comment.i64Added;
+			llDeprecatedUnix = comment.i64Deprecated;
+		}
+
+		fprintf(
+			src,
+			"\t\tthis.transport.registerOperation(this, handler, OperationIDs.OPID_%s, \"%s\", MODULE_NAME, %lld, %lld, %s);\n",
+			vd->definedName,
+			vd->definedName,
+			llAddedUnix,
+			llDeprecatedUnix,
+			bIsEvent ? "true" : "false");
 	}
 
 	fprintf(src, "\t}\n");
@@ -496,15 +517,7 @@ void PrintTSROSERemoveHandler(FILE* src, Module* m)
 	fprintf(src, "\t */\n");
 
 	fprintf(src, "\tpublic removeHandler(): void {\n");
-	ValueDef* vd;
-	FOR_EACH_LIST_ELMT(vd, m->valueDefs)
-	{
-		if (IsROSEValueDef(m, vd))
-			fprintf(src, "\t\tthis.transport.unregisterOperation(OperationIDs.OPID_%s);\n", vd->definedName);
-	}
-	if (gMajorInterfaceVersion >= 0)
-		fprintf(src, "\t\tthis.transport.unregisterModuleVersion(\"%s\");\n", m->moduleName);
-
+	fprintf(src, "\t\tthis.transport.unregisterModule(MODULE_NAME);\n");
 	fprintf(src, "\t}\n");
 }
 

--- a/compiler/back-ends/ts-gen/gen-ts-rose.c
+++ b/compiler/back-ends/ts-gen/gen-ts-rose.c
@@ -473,7 +473,7 @@ void PrintTSROSESetHandler(FILE* src, Module* m)
 
 	fprintf(src, "\tpublic setHandler(handler: Partial<I%s_Handler>): void {\n", m->ROSEClassName);
 	if (gMajorInterfaceVersion >= 0)
-		fprintf(src, "\t\tthis.transport.registerModuleVersion(MODULE_NAME, MODULE_VERSION);\n");
+		fprintf(src, "\t\tthis.transport.registerModuleVersion(%s.MODULE_NAME, %s.MODULE_VERSION);\n", GetNameSpace(m), GetNameSpace(m));
 	ValueDef* vd;
 	FOR_EACH_LIST_ELMT(vd, m->valueDefs)
 	{
@@ -498,9 +498,10 @@ void PrintTSROSESetHandler(FILE* src, Module* m)
 
 		fprintf(
 			src,
-			"\t\tthis.transport.registerOperation(this, handler, OperationIDs.OPID_%s, \"%s\", MODULE_NAME, %lld, %lld, %s);\n",
+			"\t\tthis.transport.registerOperation(this, handler, OperationIDs.OPID_%s, \"%s\", %s.MODULE_NAME, %lld, %lld, %s);\n",
 			vd->definedName,
 			vd->definedName,
+			GetNameSpace(m),
 			llAddedUnix,
 			llDeprecatedUnix,
 			bIsEvent ? "true" : "false");
@@ -517,7 +518,7 @@ void PrintTSROSERemoveHandler(FILE* src, Module* m)
 	fprintf(src, "\t */\n");
 
 	fprintf(src, "\tpublic removeHandler(): void {\n");
-	fprintf(src, "\t\tthis.transport.unregisterModule(MODULE_NAME);\n");
+	fprintf(src, "\t\tthis.transport.unregisterModule(%s.MODULE_NAME);\n", GetNameSpace(m));
 	fprintf(src, "\t}\n");
 }
 
@@ -861,9 +862,6 @@ void PrintTSROSEInterfaceCode(FILE* src, ModuleList* mods, Module* m)
 	// Import definition
 	PrintTSROSEImport(src, mods, m);
 
-	// Root types
-	PrintTSRootTypes(src, m, "ROSEInterface");
-
 	// ClientInterface definition
 	PrintTSROSEInterface(src, mods, m);
 
@@ -918,7 +916,7 @@ void PrintTSROSEClass(FILE* src, ModuleList* mods, Module* m)
 	fprintf(src, "\t */\n");
 	fprintf(src, "\tpublic getLogData(): IASN1LogData {\n");
 	fprintf(src, "\t\treturn {\n");
-	fprintf(src, "\t\t\tclassName: MODULE_NAME\n");
+	fprintf(src, "\t\t\tclassName: \"%s\"\n", m->ROSEClassName);
 	fprintf(src, "\t\t};\n");
 	fprintf(src, "\t}\n\n");
 
@@ -993,7 +991,6 @@ void PrintTSROSECode(FILE* src, ModuleList* mods, Module* m)
 {
 	PrintTSROSEHeader(src, m, false);
 	PrintTSROSEImports(src, mods, m);
-	PrintTSRootTypes(src, m, "ROSE");
 	PrintTSROSEOperationDefines(src, m, m->valueDefs);
 	PrintTSROSEModuleComment(src, m);
 	PrintTSROSEClass(src, mods, m);

--- a/compiler/back-ends/ts-gen/gluecode/TSASN1Base.registry.test.ts
+++ b/compiler/back-ends/ts-gen/gluecode/TSASN1Base.registry.test.ts
@@ -1,0 +1,69 @@
+// Run: npx tsx compiler/back-ends/ts-gen/gluecode/TSASN1Base.registry.test.ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	ASN1ClassInstanceType,
+	EASN1TransportEncoding,
+	TSASN1Base,
+} from "./TSASN1Base.js";
+import type { IASN1InvokeData } from "./TSROSEBase.js";
+import type { ROSEError, ROSEReject, ROSEResult } from "./SNACCROSE.js";
+
+class TestTransport extends TSASN1Base {
+	public constructor() {
+		super(EASN1TransportEncoding.JSON, ASN1ClassInstanceType.TSASN1NodeClient);
+	}
+
+	public sendInvoke(_data: IASN1InvokeData): Promise<ROSEReject | ROSEResult | ROSEError | undefined> {
+		return Promise.resolve(undefined);
+	}
+
+	public sendEventSync(_data: IASN1InvokeData): boolean {
+		return true;
+	}
+
+	public getSessionID(): string | undefined {
+		return undefined;
+	}
+}
+
+const noopHandler = {
+	getNameForOperationID: () => undefined,
+	getIDForOperationName: () => undefined,
+	onInvoke: async () => undefined,
+};
+
+test("registerOperation metadata appears in getLoadedModules", () => {
+	const transport = new TestTransport();
+	transport.registerModuleVersion("TestModule", "20240101.0.20240506");
+	transport.registerOperation(noopHandler, noopHandler as never, 100, "asnInvoke", "TestModule", 1714968000, 0, false);
+	transport.registerOperation(noopHandler, noopHandler as never, 200, "asnEvent", "TestModule", 0, 1715054400, true);
+
+	const modules = transport.getLoadedModules();
+	assert.equal(modules.size, 1);
+	const module = modules.get("TestModule");
+	assert.ok(module);
+	assert.equal(module.version, "20240101.0.20240506");
+	assert.equal(module.invokes.get(100)?.addedUnix, 1714968000);
+	assert.equal(module.invokes.get(100)?.deprecatedUnix, 0);
+	assert.equal(module.events.get(200)?.deprecatedUnix, 1715054400);
+
+	transport.unregisterModule("TestModule");
+	assert.equal(transport.getLoadedModules().size, 0);
+});
+
+test("separate stub instances keep separate registries", () => {
+	const transportA = new TestTransport();
+	const transportB = new TestTransport();
+
+	transportA.registerModuleVersion("ModuleA", "1.0.1");
+	transportA.registerOperation(noopHandler, noopHandler as never, 10, "opA", "ModuleA", 0, 0, false);
+
+	transportB.registerModuleVersion("ModuleB", "2.0.2");
+	transportB.registerOperation(noopHandler, noopHandler as never, 20, "opB", "ModuleB", 0, 0, true);
+
+	assert.equal(transportA.getLoadedModules().size, 1);
+	assert.equal(transportB.getLoadedModules().size, 1);
+	assert.ok(transportA.getLoadedModules().has("ModuleA"));
+	assert.ok(!transportA.getLoadedModules().has("ModuleB"));
+});

--- a/compiler/back-ends/ts-gen/gluecode/TSASN1Base.ts
+++ b/compiler/back-ends/ts-gen/gluecode/TSASN1Base.ts
@@ -23,6 +23,8 @@ import {
 	IASN1Transport,
 	IInvokeContextBase,
 	IInvokeHandler,
+	ILoadedModuleInfo,
+	IOpVersionInfo,
 	IReceiveInvokeContext,
 	IROSELogger,
 	ISendInvokeContext,
@@ -58,6 +60,14 @@ class Handler {
 	public readonly operationID: number;
 	// The operation name as specified in the ASN.1 Description
 	public readonly operationName: string;
+	// ASN.1 module that owns this operation
+	public readonly moduleName: string;
+	// @added unix timestamp from ASN.1 comments (0 = none)
+	public readonly addedUnix: number;
+	// @deprecated unix timestamp from ASN.1 comments (0 = none)
+	public readonly deprecatedUnix: number;
+	// True for ROSE events (operations without a result type)
+	public readonly isEvent: boolean;
 	// This is the object/handler which actually implements the called functionality
 	public readonly requesthandler: never;
 
@@ -74,11 +84,19 @@ class Handler {
 		requesthandler: never,
 		operationID: number,
 		operationName: string,
+		moduleName: string,
+		addedUnix: number,
+		deprecatedUnix: number,
+		isEvent: boolean,
 	) {
 		this.oninvokehandler = oninvokehandler;
 		this.requesthandler = requesthandler;
 		this.operationID = operationID;
 		this.operationName = operationName;
+		this.moduleName = moduleName;
+		this.addedUnix = addedUnix;
+		this.deprecatedUnix = deprecatedUnix;
+		this.isEvent = isEvent;
 	}
 }
 
@@ -281,8 +299,8 @@ export abstract class TSASN1Base implements IASN1Transport {
 	// Holds all registered invoke handlers
 	private handlersByID = new Map<number, Handler>();
 	private handlersByName = new Map<string, Handler>();
-	// Holds all loaded modules with their version information
-	private moduleVersionsByName = new Map<string, IModuleVersionInformation>();
+	// Holds all loaded modules with operations registered on this stub
+	private loadedModulesByName = new Map<string, ILoadedModuleInfo>();
 	// The Logger Callback which must be set with the SetLogger Method
 	protected logger?: IROSELogger;
 	// Logs the raw transport (inbound before decoding, outbound after encoding)
@@ -359,15 +377,57 @@ export abstract class TSASN1Base implements IASN1Transport {
 		requesthandler: never,
 		operationID: number,
 		operationName: string,
+		moduleName: string,
+		addedUnix: number,
+		deprecatedUnix: number,
+		isEvent: boolean,
 	): void {
 		if (!this.handlersByID.has(operationID)) {
-			const handler = new Handler(oninvokehandler, requesthandler, operationID, operationName);
+			const handler = new Handler(
+				oninvokehandler,
+				requesthandler,
+				operationID,
+				operationName,
+				moduleName,
+				addedUnix,
+				deprecatedUnix,
+				isEvent,
+			);
 			this.handlersByID.set(operationID, handler);
 			this.handlersByName.set(operationName, handler);
+			this.trackRegisteredOperation(operationID, moduleName, addedUnix, deprecatedUnix, isEvent);
 		} else {
 			// trying to re-register a handler for an already registered operationID, this should not happen and indicates a problem in the calling code
 			debugger;
 		}
+	}
+
+	/**
+	 * Records operation metadata on the loaded-module registry for this stub.
+	 */
+	private trackRegisteredOperation(
+		operationID: number,
+		moduleName: string,
+		addedUnix: number,
+		deprecatedUnix: number,
+		isEvent: boolean,
+	): void {
+		let module = this.loadedModulesByName.get(moduleName);
+		if (!module) {
+			module = {
+				moduleName,
+				version: "",
+				invokes: new Map<number, IOpVersionInfo>(),
+				events: new Map<number, IOpVersionInfo>(),
+			};
+			this.loadedModulesByName.set(moduleName, module);
+		}
+
+		const info: IOpVersionInfo = { addedUnix, deprecatedUnix };
+		if (isEvent)
+			module.events.set(operationID, info);
+		else
+			module.invokes.set(operationID, info);
 	}
 
 	/**
@@ -379,7 +439,26 @@ export abstract class TSASN1Base implements IASN1Transport {
 		if (handler) {
 			this.handlersByID.delete(operationID);
 			this.handlersByName.delete(handler.operationName);
+			const module = this.loadedModulesByName.get(handler.moduleName);
+			if (module) {
+				if (handler.isEvent)
+					module.events.delete(operationID);
+				else
+					module.invokes.delete(operationID);
+			}
 		}
+	}
+
+	/**
+	 * Removes a module and all of its registered operations from this stub.
+	 */
+	public unregisterModule(moduleName: string): void {
+		for (const operationID of [...this.handlersByID.keys()]) {
+			const handler = this.handlersByID.get(operationID);
+			if (handler?.moduleName === moduleName)
+				this.unregisterOperation(operationID);
+		}
+		this.loadedModulesByName.delete(moduleName);
 	}
 
 	/**
@@ -390,14 +469,19 @@ export abstract class TSASN1Base implements IASN1Transport {
 	 * @param majorVersion - major Version of the module
 	 * @param minorVersion - minor Version of the module
 	 */
-	public registerModuleVersion(moduleName: string, majorVersion: number, minorVersion: number): void {
-		const versionInformation: IModuleVersionInformation = {
-			moduleName,
-			majorVersion,
-			minorVersion,
-			version: `${majorVersion}.${minorVersion}`,
-		};
-		this.moduleVersionsByName.set(moduleName, versionInformation);
+	public registerModuleVersion(moduleName: string, version: string): void {
+		let module = this.loadedModulesByName.get(moduleName);
+		if (!module) {
+			module = {
+				moduleName,
+				version,
+				invokes: new Map<number, IOpVersionInfo>(),
+				events: new Map<number, IOpVersionInfo>(),
+			};
+			this.loadedModulesByName.set(moduleName, module);
+		} else {
+			module.version = version;
+		}
 	}
 
 	/**
@@ -406,7 +490,14 @@ export abstract class TSASN1Base implements IASN1Transport {
 	 * @param moduleName - name of the module to unregisters
 	 */
 	public unregisterModuleVersion(moduleName: string): void {
-		this.moduleVersionsByName.delete(moduleName);
+		this.unregisterModule(moduleName);
+	}
+
+	/**
+	 * Returns modules and operations registered on this stub instance.
+	 */
+	public getLoadedModules(): ReadonlyMap<string, ILoadedModuleInfo> {
+		return this.loadedModulesByName;
 	}
 
 	/**
@@ -416,7 +507,19 @@ export abstract class TSASN1Base implements IASN1Transport {
 	 * @returns the version information
 	 */
 	public getModuleVersion(moduleName: string): IModuleVersionInformation | undefined {
-		return this.moduleVersionsByName.get(moduleName);
+		const module = this.loadedModulesByName.get(moduleName);
+		if (!module || !module.version)
+			return undefined;
+
+		const parts = module.version.split(".");
+		const majorVersion = parts.length > 0 ? Number(parts[0]) : 0;
+		const minorVersion = parts.length > 2 ? Number(parts[2]) : 0;
+		return {
+			moduleName,
+			majorVersion: Number.isFinite(majorVersion) ? majorVersion : 0,
+			minorVersion: Number.isFinite(minorVersion) ? minorVersion : 0,
+			version: module.version,
+		};
 	}
 
 	/**
@@ -428,15 +531,18 @@ export abstract class TSASN1Base implements IASN1Transport {
 		let module: IModuleVersionInformation | undefined;
 		let majorVersion = -1;
 		let minorVersion = -1;
-		for (const mod of this.moduleVersionsByName.values()) {
-			if (mod.majorVersion > majorVersion) {
-				majorVersion = mod.majorVersion;
-				minorVersion = mod.minorVersion;
-				module = mod;
-			} else if (mod.majorVersion === majorVersion && mod.minorVersion > minorVersion) {
-				majorVersion = mod.majorVersion;
-				minorVersion = mod.minorVersion;
-				module = mod;
+		for (const loaded of this.loadedModulesByName.values()) {
+			const versionInfo = this.getModuleVersion(loaded.moduleName);
+			if (!versionInfo)
+				continue;
+			if (versionInfo.majorVersion > majorVersion) {
+				majorVersion = versionInfo.majorVersion;
+				minorVersion = versionInfo.minorVersion;
+				module = versionInfo;
+			} else if (versionInfo.majorVersion === majorVersion && versionInfo.minorVersion > minorVersion) {
+				majorVersion = versionInfo.majorVersion;
+				minorVersion = versionInfo.minorVersion;
+				module = versionInfo;
 			}
 		}
 		return module;

--- a/compiler/back-ends/ts-gen/gluecode/TSROSEBase.ts
+++ b/compiler/back-ends/ts-gen/gluecode/TSROSEBase.ts
@@ -410,6 +410,24 @@ export enum ELogSeverity {
 }
 
 /**
+ * Per-operation @added / @deprecated metadata (unix seconds; 0 = not annotated).
+ */
+export interface IOpVersionInfo {
+	addedUnix: number;
+	deprecatedUnix: number;
+}
+
+/**
+ * Module snapshot for negotiate / introspection on one stub instance.
+ */
+export interface ILoadedModuleInfo {
+	moduleName: string;
+	version: string;
+	invokes: Map<number, IOpVersionInfo>;
+	events: Map<number, IOpVersionInfo>;
+}
+
+/**
  * Defines the interface the logger has to fullfill in order to handle log messages from the rose stub
  */
 export interface IROSELogger {
@@ -443,10 +461,16 @@ export interface IASN1Transport {
 		requesthandler: unknown,
 		operationID: number,
 		operationName: string,
+		moduleName: string,
+		addedUnix: number,
+		deprecatedUnix: number,
+		isEvent: boolean,
 	): void;
 	unregisterOperation(operationID: number): void;
-	registerModuleVersion(moduleName: string, majorVersion: number, minorVersion: number): void;
+	unregisterModule(moduleName: string): void;
+	registerModuleVersion(moduleName: string, version: string): void;
 	unregisterModuleVersion(moduleName: string): void;
+	getLoadedModules(): ReadonlyMap<string, ILoadedModuleInfo>;
 	getInvokeContextParams(
 		context: Partial<ISendInvokeContextParams> | undefined,
 		operationID: number,

--- a/compiler/core/asn_commentparser.cpp
+++ b/compiler/core/asn_commentparser.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <assert.h>
 #include <set>
+#include <map>
 #ifndef _WIN32
 #include <unistd.h>
 #endif
@@ -67,6 +68,152 @@ void warnDeprecatedSuccessorIfNeeded(EDeprecated& deprecated, const char* szFile
 		deprecated.iDeprecatedSuccessorInvalid = 1;
 		EmitDeprecatedSuccessorMissingWarning(szFileName, deprecated.iDeprecatedLine, szSymbolName);
 	}
+}
+
+std::string normalizeModuleKey(const char* szModuleName)
+{
+	if (!szModuleName)
+		return {};
+	std::string moduleKey = szModuleName;
+	const auto dotPos = moduleKey.find_first_of(".");
+	if (dotPos != std::string::npos)
+		moduleKey = moduleKey.substr(0, dotPos);
+	return moduleKey;
+}
+
+std::set<std::string> collectLocalSymbolsForModule(const std::string& moduleKey)
+{
+	const std::string prefix = moduleKey + "::";
+	std::set<std::string> localSymbols;
+	for (const auto& operationComment : gComments.mapOperations)
+	{
+		if (operationComment.first.rfind(prefix, 0) != 0)
+			continue;
+		localSymbols.insert(operationComment.second.strTypeName_UTF8);
+	}
+	for (const auto& sequenceComment : gComments.mapSequences)
+	{
+		if (sequenceComment.first.rfind(prefix, 0) != 0)
+			continue;
+		localSymbols.insert(sequenceComment.second.strTypeName_UTF8);
+	}
+	return localSymbols;
+}
+
+using ModuleSymbolIndex = std::map<std::string, std::set<std::string>>;
+
+ModuleSymbolIndex buildModuleSymbolIndex()
+{
+	ModuleSymbolIndex index;
+	for (const auto& operationComment : gComments.mapOperations)
+	{
+		const auto sep = operationComment.first.find("::");
+		if (sep == std::string::npos)
+			continue;
+		index[operationComment.first.substr(0, sep)].insert(operationComment.second.strTypeName_UTF8);
+	}
+	for (const auto& sequenceComment : gComments.mapSequences)
+	{
+		const auto sep = sequenceComment.first.find("::");
+		if (sep == std::string::npos)
+			continue;
+		index[sequenceComment.first.substr(0, sep)].insert(sequenceComment.second.strTypeName_UTF8);
+	}
+	return index;
+}
+
+std::vector<std::string> resolveLoadedSuccessorModules(const std::string& qualifier, const ModuleSymbolIndex& moduleSymbols)
+{
+	std::vector<std::string> resolvedModules;
+	if (qualifier.empty())
+		return resolvedModules;
+
+	if (moduleSymbols.find(qualifier) != moduleSymbols.end())
+	{
+		resolvedModules.push_back(qualifier);
+		return resolvedModules;
+	}
+
+	if (qualifier == "UCWeb")
+	{
+		for (const auto& moduleEntry : moduleSymbols)
+		{
+			if (moduleEntry.first.rfind("EUCWeb_", 0) == 0)
+				resolvedModules.push_back(moduleEntry.first);
+		}
+	}
+
+	return resolvedModules;
+}
+
+bool successorExistsInModules(
+	const std::string& successorSymbol,
+	const std::vector<std::string>& moduleKeys,
+	const ModuleSymbolIndex& moduleSymbols)
+{
+	for (const auto& moduleKey : moduleKeys)
+	{
+		const auto moduleIt = moduleSymbols.find(moduleKey);
+		if (moduleIt == moduleSymbols.end())
+			continue;
+		if (moduleIt->second.find(successorSymbol) != moduleIt->second.end())
+			return true;
+	}
+	return false;
+}
+
+std::string formatResolvedModuleLabel(const std::string& qualifier, const std::vector<std::string>& moduleKeys)
+{
+	if (moduleKeys.size() == 1)
+		return moduleKeys.front();
+	if (qualifier == "UCWeb")
+		return "UCWeb (EUCWeb_*)";
+	return qualifier;
+}
+
+void validateSameFileDeprecatedSuccessor(
+	const EDeprecated& deprecated,
+	const char* pszFileName,
+	const char* pszSymbolName,
+	const std::set<std::string>& localSymbols)
+{
+	if (deprecated.i64Deprecated <= 0 || !deprecated.bSuccessorParsed)
+		return;
+	if (deprecated.successorScope != EDeprecatedSuccessorSameFile)
+		return;
+	if (localSymbols.find(deprecated.successorSymbol) == localSymbols.end())
+		EmitDeprecatedSuccessorNotInFileWarning(
+			pszFileName,
+			deprecated.iDeprecatedLine,
+			pszSymbolName,
+			deprecated.successorSymbol.c_str());
+}
+
+void validateQualifiedDeprecatedSuccessor(
+	const EDeprecated& deprecated,
+	const char* pszFileName,
+	const char* pszSymbolName,
+	const ModuleSymbolIndex& moduleSymbols)
+{
+	if (deprecated.i64Deprecated <= 0 || !deprecated.bSuccessorParsed)
+		return;
+	if (deprecated.successorScope != EDeprecatedSuccessorQualified)
+		return;
+
+	const std::vector<std::string> resolvedModules = resolveLoadedSuccessorModules(deprecated.successorQualifier, moduleSymbols);
+	if (resolvedModules.empty())
+		return;
+
+	if (successorExistsInModules(deprecated.successorSymbol, resolvedModules, moduleSymbols))
+		return;
+
+	EmitDeprecatedSuccessorNotInModuleWarning(
+		pszFileName,
+		deprecated.iDeprecatedLine,
+		pszSymbolName,
+		deprecated.successorQualifier.c_str(),
+		deprecated.successorSymbol.c_str(),
+		formatResolvedModuleLabel(deprecated.successorQualifier, resolvedModules).c_str());
 }
 } // namespace
 
@@ -571,7 +718,7 @@ void convertMemberCommentList(
 		}
 	}
 
-	pType->finishDeprecatedSuccessorCommentBlock(szFileName, szSymbolName);
+	// SEQUENCE / ENUMERATED / CHOICE members: @deprecated successor arrows are context-specific and not validated.
 }
 
 int EAsnStackElementFile::ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state)
@@ -1319,38 +1466,13 @@ void EAsnCommentParser::ValidateDeprecatedSuccessorsForModule(const char* szModu
 	if (!szModuleName)
 		return;
 
-	std::string moduleKey = szModuleName;
-	const auto dotPos = moduleKey.find_first_of(".");
-	if (dotPos != std::string::npos)
-		moduleKey = moduleKey.substr(0, dotPos);
-
+	const std::string moduleKey = normalizeModuleKey(szModuleName);
 	const std::string prefix = moduleKey + "::";
-	std::set<std::string> localSymbols;
-	for (const auto& operationComment : gComments.mapOperations)
-	{
-		if (operationComment.first.rfind(prefix, 0) != 0)
-			continue;
-		localSymbols.insert(operationComment.second.strTypeName_UTF8);
-	}
-	for (const auto& sequenceComment : gComments.mapSequences)
-	{
-		if (sequenceComment.first.rfind(prefix, 0) != 0)
-			continue;
-		localSymbols.insert(sequenceComment.second.strTypeName_UTF8);
-	}
+	const std::set<std::string> localSymbols = collectLocalSymbolsForModule(moduleKey);
 
 	const auto checkDeprecated = [&](const EDeprecated& deprecated, const char* pszSymbolName)
 	{
-		if (deprecated.i64Deprecated <= 0 || !deprecated.bSuccessorParsed)
-			return;
-		if (deprecated.successorScope != EDeprecatedSuccessorSameFile)
-			return;
-		if (localSymbols.find(deprecated.successorSymbol) == localSymbols.end())
-			EmitDeprecatedSuccessorNotInFileWarning(
-				szModuleName,
-				deprecated.iDeprecatedLine,
-				pszSymbolName,
-				deprecated.successorSymbol.c_str());
+		validateSameFileDeprecatedSuccessor(deprecated, szModuleName, pszSymbolName, localSymbols);
 	};
 
 	for (const auto& operationComment : gComments.mapOperations)
@@ -1364,13 +1486,47 @@ void EAsnCommentParser::ValidateDeprecatedSuccessorsForModule(const char* szModu
 		if (sequenceComment.first.rfind(prefix, 0) != 0)
 			continue;
 		checkDeprecated(sequenceComment.second, sequenceComment.second.strTypeName_UTF8.c_str());
-		for (const auto& memberComment : sequenceComment.second.mapMembers)
-			checkDeprecated(memberComment.second, memberComment.first.c_str());
 	}
 
 	const auto moduleIt = gComments.mapModules.find(moduleKey);
 	if (moduleIt != gComments.mapModules.end())
 		checkDeprecated(moduleIt->second, moduleIt->second.strTypeName_UTF8.c_str());
+}
+
+void EAsnCommentParser::ValidateAllDeprecatedSuccessors()
+{
+	const ModuleSymbolIndex moduleSymbols = buildModuleSymbolIndex();
+	if (moduleSymbols.empty())
+		return;
+
+	const auto checkDeprecated = [&](const EDeprecated& deprecated, const char* pszFileName, const char* pszSymbolName)
+	{
+		validateQualifiedDeprecatedSuccessor(deprecated, pszFileName, pszSymbolName, moduleSymbols);
+	};
+
+	for (const auto& moduleComment : gComments.mapModules)
+		checkDeprecated(moduleComment.second, moduleComment.first.c_str(), moduleComment.second.strTypeName_UTF8.c_str());
+
+	for (const auto& operationComment : gComments.mapOperations)
+	{
+		const auto sep = operationComment.first.find("::");
+		if (sep == std::string::npos)
+			continue;
+		const std::string moduleKey = operationComment.first.substr(0, sep);
+		checkDeprecated(
+			operationComment.second,
+			moduleKey.c_str(),
+			operationComment.second.strTypeName_UTF8.c_str());
+	}
+
+	for (const auto& sequenceComment : gComments.mapSequences)
+	{
+		const auto sep = sequenceComment.first.find("::");
+		if (sep == std::string::npos)
+			continue;
+		const std::string moduleKey = sequenceComment.first.substr(0, sep);
+		checkDeprecated(sequenceComment.second, moduleKey.c_str(), sequenceComment.second.strTypeName_UTF8.c_str());
+	}
 }
 
 void EAsnCommentParser::FilterFiles()

--- a/compiler/core/asn_commentparser.cpp
+++ b/compiler/core/asn_commentparser.cpp
@@ -3,6 +3,7 @@
 #include "asn-stringconvert.h"
 #include "filetype.h"
 #include "snacc-validation-rules.h"
+#include "snacc-deprecated-successor.h"
 #include "../../snacc.h"
 #include "time_helpers.h"
 #include <stdio.h>
@@ -14,11 +15,12 @@
 #include <time.h>
 #include <vector>
 #include <assert.h>
+#include <set>
 #ifndef _WIN32
 #include <unistd.h>
 #endif
 
-const std::string WHITESPACE = " \n\r\t\f\v";
+std::string escapeJsonString(const std::string& input);
 
 namespace
 {
@@ -33,6 +35,39 @@ constexpr std::string_view kTagLogfilter = "@logfilter";
 constexpr std::string_view kTagLinked = "@linked";
 constexpr std::string_view kTagClear = "@clear";
 constexpr std::string_view kCommentIgnoredPrefix = "-- ~";
+
+const std::string WHITESPACE = " \n\r\t\f\v";
+
+void pushCollectedComment(std::list<std::string>& comments, std::list<int>& commentLines, const std::string& comment, int lineNo)
+{
+	comments.push_back(comment);
+	commentLines.push_back(lineNo);
+}
+
+void applyDeprecatedSuccessorFields(EDeprecated& deprecated, const DeprecatedSuccessorFields& fields)
+{
+	if (!fields.parsed)
+		return;
+
+	deprecated.bSuccessorParsed = true;
+	deprecated.successorScope = fields.scope;
+	deprecated.successorSymbol = fields.symbol;
+	deprecated.successorQualifier = fields.qualifier;
+	if (!fields.proseAfter.empty())
+		deprecated.strDeprecated_UTF8 = escapeJsonString(fields.proseAfter);
+}
+
+void warnDeprecatedSuccessorIfNeeded(EDeprecated& deprecated, const char* szFileName, const char* szSymbolName)
+{
+	if (deprecated.i64Deprecated <= 0)
+		return;
+
+	if (!deprecated.bSuccessorParsed || deprecated.iDeprecatedSuccessorInvalid)
+	{
+		deprecated.iDeprecatedSuccessorInvalid = 1;
+		EmitDeprecatedSuccessorMissingWarning(szFileName, deprecated.iDeprecatedLine, szSymbolName);
+	}
+}
 } // namespace
 
 bool isFiltered(const ETypeComment& comment)
@@ -127,11 +162,11 @@ char* ConvertUnixTimeToReverseTimeString(const long long tmUnixTime)
 	return szBuffer;
 }
 
-void EDeprecated::handleDeprecated(const std::string& strParsedLine)
+void EDeprecated::handleDeprecated(const std::string& strParsedLine, int lineNo)
 {
 	std::string strComment = trim(strParsedLine);
 	// Check is ther a date in the value?
-	// @deprecated 1.1.2023 Some comment
+	// @deprecated 1.1.2023 -> Symbol
 	auto pos = strComment.find(" ");
 	if (pos == std::string::npos)
 		pos = strComment.length();
@@ -149,14 +184,47 @@ void EDeprecated::handleDeprecated(const std::string& strParsedLine)
 			strComment = trim(strComment.substr(strDate.length()));
 		}
 	}
-	if (strComment.length())
-		strDeprecated_UTF8 = escapeJsonString(strComment);
+
+	DeprecatedSuccessorFields fields;
+	std::string textWithoutSuccessor;
+	if (FindAndParseDeprecatedSuccessorInText(strComment, fields, textWithoutSuccessor))
+		applyDeprecatedSuccessorFields(*this, fields);
+	else
+		textWithoutSuccessor = strComment;
+
+	if (textWithoutSuccessor.length())
+		strDeprecated_UTF8 = escapeJsonString(textWithoutSuccessor);
 
 	if (i64Deprecated <= 0)
 	{
 		fprintf(stderr, "WARNING - @deprecated flag is missing or has a broken timestamp. '%s'", strComment.c_str());
 		i64Deprecated = 1;
 	}
+
+	if (lineNo > 0)
+		iDeprecatedLine = lineNo;
+}
+
+void EDeprecated::tryParseSuccessorArrowLine(const std::string& strLine, int lineNo)
+{
+	DeprecatedSuccessorFields fields;
+	if (!ParseDeprecatedSuccessorArrowLine(trim(strLine), fields))
+		return;
+
+	if (bSuccessorParsed)
+	{
+		iDeprecatedSuccessorInvalid = 1;
+		return;
+	}
+
+	applyDeprecatedSuccessorFields(*this, fields);
+	if (lineNo > 0)
+		iDeprecatedLine = lineNo;
+}
+
+void EDeprecated::finishDeprecatedSuccessorCommentBlock(const char* szFileName, const char* szSymbolName)
+{
+	warnDeprecatedSuccessorIfNeeded(*this, szFileName, szSymbolName);
 }
 
 void EAdded::handleAdded(const std::string& strParsedLine)
@@ -257,7 +325,12 @@ std::string escapeJsonString(const std::string& input)
 	return ss.str();
 }
 
-void convertCommentList(std::list<std::string>& commentList, ETypeComment* pType)
+void convertCommentList(
+	std::list<std::string>& commentList,
+	std::list<int>& commentLines,
+	ETypeComment* pType,
+	const char* szFileName,
+	const char* szSymbolName)
 {
 	if (!pType)
 	{
@@ -267,9 +340,12 @@ void convertCommentList(std::list<std::string>& commentList, ETypeComment* pType
 	}
 	bool bInLong = true;
 	bool bInBrief = false;
+	bool bAwaitingSuccessor = false;
 	int nEmptyLines = 0;
+	auto lineIt = commentLines.begin();
 	for (auto el = commentList.begin(); el != commentList.end(); el++)
 	{
+		const int lineNo = lineIt != commentLines.end() ? *lineIt++ : 0;
 		std::string strLine = trim(*el);
 		if (strLine.starts_with(kTagBrief))
 		{
@@ -298,7 +374,10 @@ void convertCommentList(std::list<std::string>& commentList, ETypeComment* pType
 		else if (strLine.starts_with(kTagDeprecated))
 		{
 			nEmptyLines = 0;
-			pType->handleDeprecated(remainderAfterTag(strLine, kTagDeprecated));
+			bAwaitingSuccessor = false;
+			pType->handleDeprecated(trimmedRemainderAfterTag(strLine, kTagDeprecated), lineNo);
+			if (!pType->bSuccessorParsed)
+				bAwaitingSuccessor = true;
 			// We do not change the flags here, the keyword @deprecated may lead or follow any comment
 			// bInLong = false;
 			// bInBrief = false;
@@ -345,6 +424,12 @@ void convertCommentList(std::list<std::string>& commentList, ETypeComment* pType
 		}
 		else
 		{
+			if (bAwaitingSuccessor && trim(strLine).starts_with("->"))
+			{
+				pType->tryParseSuccessorArrowLine(strLine, lineNo);
+				bAwaitingSuccessor = !pType->bSuccessorParsed;
+			}
+
 			strLine = trim(strLine);
 			if (bInLong)
 			{
@@ -386,9 +471,16 @@ void convertCommentList(std::list<std::string>& commentList, ETypeComment* pType
 		pType->strLong_UTF8 += escapeJsonString("\n");
 	if (!pType->strShort_UTF8.empty())
 		pType->strShort_UTF8 += escapeJsonString("\n");
+
+	pType->finishDeprecatedSuccessorCommentBlock(szFileName, szSymbolName);
 }
 
-void convertMemberCommentList(std::list<std::string>& commentList, EStructMemberComment* pType)
+void convertMemberCommentList(
+	std::list<std::string>& commentList,
+	std::list<int>& commentLines,
+	EStructMemberComment* pType,
+	const char* szFileName,
+	const char* szSymbolName)
 {
 	enum class eLast
 	{
@@ -401,9 +493,12 @@ void convertMemberCommentList(std::list<std::string>& commentList, EStructMember
 	};
 
 	eLast last = eLast::_unknown;
+	bool bAwaitingSuccessor = false;
+	auto lineIt = commentLines.begin();
 
 	for (auto el = commentList.begin(); el != commentList.end(); el++)
 	{
+		const int lineNo = lineIt != commentLines.end() ? *lineIt++ : 0;
 		std::string strLine = trim(*el);
 		if (strLine.starts_with(kTagBrief))
 		{
@@ -419,7 +514,10 @@ void convertMemberCommentList(std::list<std::string>& commentList, EStructMember
 		else if (strLine.starts_with(kTagDeprecated))
 		{
 			last = eLast::_deprecated;
-			pType->handleDeprecated(remainderAfterTag(strLine, kTagDeprecated));
+			bAwaitingSuccessor = false;
+			pType->handleDeprecated(trimmedRemainderAfterTag(strLine, kTagDeprecated), lineNo);
+			if (!pType->bSuccessorParsed)
+				bAwaitingSuccessor = true;
 		}
 		else if (strLine.starts_with(kTagAdded))
 		{
@@ -443,6 +541,12 @@ void convertMemberCommentList(std::list<std::string>& commentList, EStructMember
 		}
 		else
 		{
+			if (bAwaitingSuccessor && trim(strLine).starts_with("->"))
+			{
+				pType->tryParseSuccessorArrowLine(strLine, lineNo);
+				bAwaitingSuccessor = !pType->bSuccessorParsed;
+			}
+
 			strLine = trim(strLine);
 			if (last == eLast::_brief)
 			{
@@ -466,6 +570,8 @@ void convertMemberCommentList(std::list<std::string>& commentList, EStructMember
 			}
 		}
 	}
+
+	pType->finishDeprecatedSuccessorCommentBlock(szFileName, szSymbolName);
 }
 
 int EAsnStackElementFile::ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state)
@@ -477,9 +583,12 @@ int EAsnStackElementFile::ProcessLine(const char* szModuleName, const char* szRa
 		if (!szComment.empty())
 		{
 			if (szComment.starts_with(kTagClear))
+			{
 				m_CollectComments.clear();
+				m_CollectCommentLines.clear();
+			}
 			else
-				m_CollectComments.push_back(szComment);
+				pushCollectedComment(m_CollectComments, m_CollectCommentLines, szComment, m_pParser->m_iSourceLine);
 		}
 		return 0;
 	}
@@ -493,8 +602,15 @@ int EAsnStackElementFile::ProcessLine(const char* szModuleName, const char* szRa
 		if (strBegin == "BEGIN")
 		{
 			EAsnStackElementModule* el = new EAsnStackElementModule(m_pParser);
-			el->SetModuleProperties(m_strModuleName.c_str(), m_strModuleName.c_str(), m_strModuleASN1Name.c_str(), m_CollectComments);
+			el->SetModuleProperties(
+				m_strModuleName.c_str(),
+				m_strModuleName.c_str(),
+				m_strModuleName.c_str(),
+				m_strModuleASN1Name.c_str(),
+				m_CollectComments,
+				m_CollectCommentLines);
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			m_pParser->m_stack.push_back(el);
 
 			return 0;
@@ -509,12 +625,18 @@ int EAsnStackElementFile::ProcessLine(const char* szModuleName, const char* szRa
 	return 0;
 }
 
-void EAsnStackElementModule::SetModuleProperties(const char* szTypeName, const char* szCategory, const char* szASN1ModuleName, std::list<std::string>& listComments)
+void EAsnStackElementModule::SetModuleProperties(
+	const char* szFileName,
+	const char* szTypeName,
+	const char* szCategory,
+	const char* szASN1ModuleName,
+	std::list<std::string>& listComments,
+	std::list<int>& listCommentLines)
 {
 	m_ModuleComment.strTypeName_UTF8 = szTypeName;
 	m_ModuleComment.strCategory_UTF8 = szCategory;
 	m_ModuleComment.m_strASN1ModuleName = szASN1ModuleName;
-	convertCommentList(listComments, &m_ModuleComment);
+	convertCommentList(listComments, listCommentLines, &m_ModuleComment, szFileName, szTypeName);
 }
 
 int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state)
@@ -531,6 +653,7 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 
 		m_ModuleComment.setModuleName(strKey.c_str());
 		gComments.mapModules[strKey] = m_ModuleComment;
+		m_pParser->ValidateDeprecatedSuccessorsForModule(szModuleName);
 
 		if (isFiltered(m_ModuleComment))
 			state = EElementState::end_and_filtered;
@@ -549,9 +672,12 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 		if (!szComment.empty())
 		{
 			if (szComment.starts_with(kTagClear))
+			{
 				m_CollectComments.clear();
+				m_CollectCommentLines.clear();
+			}
 			else
-				m_CollectComments.push_back(szComment);
+				pushCollectedComment(m_CollectComments, m_CollectCommentLines, szComment, m_pParser->m_iSourceLine);
 		}
 		return 0;
 	}
@@ -620,6 +746,7 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 			el->m_comment.strTypeName_UTF8 = strType;
 			el->m_comment.strCategory_UTF8 = m_ModuleComment.strCategory_UTF8;
 			el->commentsBefore = m_CollectComments;
+			el->commentsBeforeLines = m_CollectCommentLines;
 
 			szLine.clear();
 			EElementState elementState = EElementState::not_yet_ended;
@@ -633,46 +760,51 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 			delete el;
 
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 		else if (strBasicType1 == "SEQUENCE" && (strBasicType2 == "" || strBasicType2 == "{"))
 		{
 			EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-			el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), &m_ModuleComment, m_CollectComments);
+			el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), &m_ModuleComment, m_CollectComments, m_CollectCommentLines);
 
 			m_pParser->m_stack.push_back(el);
 
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 		else if (strBasicType1 == "ENUMERATED" && (strBasicType2 == "" || strBasicType2 == "{"))
 		{
 			EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-			el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), &m_ModuleComment, m_CollectComments);
+			el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), &m_ModuleComment, m_CollectComments, m_CollectCommentLines);
 
 			m_pParser->m_stack.push_back(el);
 
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 		else if (strBasicType1 == "BIT" && strBasicType2 == "STRING")
 		{
 			EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-			el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), &m_ModuleComment, m_CollectComments);
+			el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), &m_ModuleComment, m_CollectComments, m_CollectCommentLines);
 
 			m_pParser->m_stack.push_back(el);
 
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 		else if (strBasicType1 == "CHOICE" && (strBasicType2 == "" || strBasicType2 == "{"))
 		{
 			EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-			el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), &m_ModuleComment, m_CollectComments);
+			el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), &m_ModuleComment, m_CollectComments, m_CollectCommentLines);
 
 			m_pParser->m_stack.push_back(el);
 
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 		else
@@ -681,7 +813,7 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 			ESequenceComment comment;
 			comment.strTypeName_UTF8 = strType;
 			comment.strCategory_UTF8 = m_ModuleComment.strCategory_UTF8;
-			convertCommentList(m_CollectComments, &comment);
+			convertCommentList(m_CollectComments, m_CollectCommentLines, &comment, szModuleName, strType.c_str());
 
 			if (!isFiltered(comment))
 				m_strFilteredFileContent += m_strRawSourceFileIncrement;
@@ -696,6 +828,7 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 			gComments.mapSequences[strKey] = comment;
 
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 	}
@@ -709,21 +842,23 @@ int EAsnStackElementModule::ProcessLine(const char* szModuleName, const char* sz
 		if (iterTokens != tokens.end() && *iterTokens == "OPERATION")
 		{
 			EAsnStackElementOperation* el = new EAsnStackElementOperation(m_pParser);
-			el->SetOperationProperties(strType.c_str(), &m_ModuleComment, m_CollectComments);
+			el->SetOperationProperties(szModuleName, strType.c_str(), &m_ModuleComment, m_CollectComments, m_CollectCommentLines);
 			m_pParser->m_stack.push_back(el);
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			return 0;
 		}
 		else
 		{
 			ESequenceComment comment;
-			convertCommentList(m_CollectComments, &comment);
+			convertCommentList(m_CollectComments, m_CollectCommentLines, &comment, szModuleName, strType.c_str());
 			if (!isFiltered(comment))
 			{
 				m_strFilteredFileContent += m_strRawSourceFileIncrement;
 				m_strRawSourceFileIncrement.clear();
 			}
 			m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 		}
 
 		return 0;
@@ -737,7 +872,13 @@ bool EAsnStackElementModule::isModuleFiltered() const
 	return isFiltered(m_ModuleComment);
 }
 
-void EAsnStackElementSequence::SetSequenceProperties(bool bOpenBracket, const char* szTypeName, EModuleComment* pmodcomment, std::list<std::string>& listComments)
+void EAsnStackElementSequence::SetSequenceProperties(
+	bool bOpenBracket,
+	const char* szFileName,
+	const char* szTypeName,
+	EModuleComment* pmodcomment,
+	std::list<std::string>& listComments,
+	std::list<int>& listCommentLines)
 {
 	bOpenBracketFound = bOpenBracket;
 	m_comment.strTypeName_UTF8 = szTypeName;
@@ -746,7 +887,7 @@ void EAsnStackElementSequence::SetSequenceProperties(bool bOpenBracket, const ch
 	m_comment.i64Deprecated = pmodcomment->i64Deprecated;
 	m_comment.i64Added = pmodcomment->i64Added;
 	m_pmodcomment = pmodcomment;
-	convertCommentList(listComments, &m_comment);
+	convertCommentList(listComments, listCommentLines, &m_comment, szFileName, szTypeName);
 }
 
 int EAsnStackElementSequence::ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state)
@@ -770,7 +911,7 @@ int EAsnStackElementSequence::ProcessLine(const char* szModuleName, const char* 
 	if (szLine.empty())
 	{
 		if (!szComment.empty())
-			m_CollectComments.push_back(szComment);
+			pushCollectedComment(m_CollectComments, m_CollectCommentLines, szComment, m_pParser->m_iSourceLine);
 		return 0;
 	}
 
@@ -790,11 +931,11 @@ int EAsnStackElementSequence::ProcessLine(const char* szModuleName, const char* 
 			replaceAll(strMember, "-", "_");
 
 			if (szComment.size())
-				m_CollectComments.push_back(szComment);
+				pushCollectedComment(m_CollectComments, m_CollectCommentLines, szComment, m_pParser->m_iSourceLine);
 
 			EStructMemberComment member;
 
-			convertMemberCommentList(m_CollectComments, &member);
+			convertMemberCommentList(m_CollectComments, m_CollectCommentLines, &member, szModuleName, strMember.c_str());
 			m_comment.mapMembers[strMember] = member;
 
 			if (!isFiltered(member))
@@ -821,48 +962,54 @@ int EAsnStackElementSequence::ProcessLine(const char* szModuleName, const char* 
 				el->m_comment.strTypeName_UTF8 = strType;
 				el->m_comment.strCategory_UTF8 = m_comment.strCategory_UTF8;
 				el->commentsBefore = m_CollectComments;
+			el->commentsBeforeLines = m_CollectCommentLines;
 
 				m_pParser->m_stack.push_back(el);
 
 				m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 				return 0;
 			}
 			else if (strBasicType1 == "SEQUENCE" && (strBasicType2 == "" || strBasicType2 == "{"))
 			{
 				std::string strType = m_comment.strTypeName_UTF8 + "Seq";
 				EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-				el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), m_pmodcomment, m_CollectComments);
+				el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), m_pmodcomment, m_CollectComments, m_CollectCommentLines);
 
 				m_pParser->m_stack.push_back(el);
 
 				m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 				return 0;
 			}
 			else if (strBasicType1 == "ENUMERATED" && (strBasicType2 == "" || strBasicType2 == "{"))
 			{
 				std::string strType = m_comment.strTypeName_UTF8 + "Enum";
 				EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-				el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), m_pmodcomment, m_CollectComments);
+				el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), m_pmodcomment, m_CollectComments, m_CollectCommentLines);
 
 				m_pParser->m_stack.push_back(el);
 
 				m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 				return 0;
 			}
 			else if (strBasicType1 == "CHOICE" && (strBasicType2 == "" || strBasicType2 == "{"))
 			{
 				std::string strType = m_comment.strTypeName_UTF8 + "Choice";
 				EAsnStackElementSequence* el = new EAsnStackElementSequence(m_pParser);
-				el->SetSequenceProperties(strBasicType2 == "{", strType.c_str(), m_pmodcomment, m_CollectComments);
+				el->SetSequenceProperties(strBasicType2 == "{", szModuleName, strType.c_str(), m_pmodcomment, m_CollectComments, m_CollectCommentLines);
 
 				m_pParser->m_stack.push_back(el);
 
 				m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 				return 0;
 			}
 			else
 			{
 				m_CollectComments.clear();
+			m_CollectCommentLines.clear();
 			}
 		}
 	}
@@ -902,8 +1049,9 @@ int EAsnStackElementSequenceOf::ProcessLine(const char* szModuleName, const char
 
 	// sequence of is complete on the next line anyway
 	// add comments before the sequence...
-	convertCommentList(commentsBefore, &m_comment);
+	convertCommentList(commentsBefore, commentsBeforeLines, &m_comment, szModuleName, m_comment.strTypeName_UTF8.c_str());
 	commentsBefore.clear();
+	commentsBeforeLines.clear();
 
 	std::string strKey = szModuleName;
 	const auto pos = strKey.find_first_of(".");
@@ -926,14 +1074,19 @@ int EAsnStackElementSequenceOf::ProcessLine(const char* szModuleName, const char
 	return 0;
 }
 
-void EAsnStackElementOperation::SetOperationProperties(const char* szTypeName, EModuleComment* pmodcomment, std::list<std::string>& listComments)
+void EAsnStackElementOperation::SetOperationProperties(
+	const char* szFileName,
+	const char* szTypeName,
+	EModuleComment* pmodcomment,
+	std::list<std::string>& listComments,
+	std::list<int>& listCommentLines)
 {
 	m_comment.strTypeName_UTF8 = szTypeName;
 	m_comment.strCategory_UTF8 = pmodcomment->strCategory_UTF8;
 	m_comment.iPrivate = pmodcomment->iPrivate;
 	m_comment.i64Deprecated = pmodcomment->i64Deprecated;
 	m_comment.i64Added = pmodcomment->i64Added;
-	convertCommentList(listComments, &m_comment);
+	convertCommentList(listComments, listCommentLines, &m_comment, szFileName, szTypeName);
 }
 
 int EAsnStackElementOperation::ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state)
@@ -977,6 +1130,7 @@ int EAsnCommentParser::ParseFileForComments(FILE* fp, const char* szModuleName, 
 	// set to beginning of file
 	fseek(fp, type == UTF8WITHBOM ? 3 : 0, SEEK_SET);
 
+	m_iSourceLine = 0;
 	m_stack.clear();
 
 	m_stack.push_back(new EAsnStackElementFile(this, szModuleName));
@@ -1160,6 +1314,65 @@ std::string EAsnCommentParser::FilterImports(const std::string& strImports)
 	return strResult;
 }
 
+void EAsnCommentParser::ValidateDeprecatedSuccessorsForModule(const char* szModuleName)
+{
+	if (!szModuleName)
+		return;
+
+	std::string moduleKey = szModuleName;
+	const auto dotPos = moduleKey.find_first_of(".");
+	if (dotPos != std::string::npos)
+		moduleKey = moduleKey.substr(0, dotPos);
+
+	const std::string prefix = moduleKey + "::";
+	std::set<std::string> localSymbols;
+	for (const auto& operationComment : gComments.mapOperations)
+	{
+		if (operationComment.first.rfind(prefix, 0) != 0)
+			continue;
+		localSymbols.insert(operationComment.second.strTypeName_UTF8);
+	}
+	for (const auto& sequenceComment : gComments.mapSequences)
+	{
+		if (sequenceComment.first.rfind(prefix, 0) != 0)
+			continue;
+		localSymbols.insert(sequenceComment.second.strTypeName_UTF8);
+	}
+
+	const auto checkDeprecated = [&](const EDeprecated& deprecated, const char* pszSymbolName)
+	{
+		if (deprecated.i64Deprecated <= 0 || !deprecated.bSuccessorParsed)
+			return;
+		if (deprecated.successorScope != EDeprecatedSuccessorSameFile)
+			return;
+		if (localSymbols.find(deprecated.successorSymbol) == localSymbols.end())
+			EmitDeprecatedSuccessorNotInFileWarning(
+				szModuleName,
+				deprecated.iDeprecatedLine,
+				pszSymbolName,
+				deprecated.successorSymbol.c_str());
+	};
+
+	for (const auto& operationComment : gComments.mapOperations)
+	{
+		if (operationComment.first.rfind(prefix, 0) != 0)
+			continue;
+		checkDeprecated(operationComment.second, operationComment.second.strTypeName_UTF8.c_str());
+	}
+	for (const auto& sequenceComment : gComments.mapSequences)
+	{
+		if (sequenceComment.first.rfind(prefix, 0) != 0)
+			continue;
+		checkDeprecated(sequenceComment.second, sequenceComment.second.strTypeName_UTF8.c_str());
+		for (const auto& memberComment : sequenceComment.second.mapMembers)
+			checkDeprecated(memberComment.second, memberComment.first.c_str());
+	}
+
+	const auto moduleIt = gComments.mapModules.find(moduleKey);
+	if (moduleIt != gComments.mapModules.end())
+		checkDeprecated(moduleIt->second, moduleIt->second.strTypeName_UTF8.c_str());
+}
+
 void EAsnCommentParser::FilterFiles()
 {
 	if (!gFilterASN1Files)
@@ -1235,6 +1448,7 @@ void EAsnCommentParser::FilterFiles()
 
 int EAsnCommentParser::ProcessLine(const char* szModuleName, const char* szLine)
 {
+	++m_iSourceLine;
 	int iResult = 1; // error
 
 	std::string strLine(szLine);

--- a/compiler/core/asn_commentparser.h
+++ b/compiler/core/asn_commentparser.h
@@ -184,8 +184,10 @@ public:
 	void RegisterFilterSource(const char* szSourcePath, const char* szModuleName, enum EFILETYPE type);
 	// Re-parses registered sources when -nodeprecated was resolved after the first pass
 	void RebuildFilteredAsnFiles();
-	// Warn-only validation of same-file @deprecated successors after a module is fully parsed
+	// Warn-only validation of @deprecated successors after a module is fully parsed (same file)
 	void ValidateDeprecatedSuccessorsForModule(const char* szModuleName);
+	// Warn-only validation of qualified @deprecated successors after all modules are parsed
+	void ValidateAllDeprecatedSuccessors();
 
 	std::list<EAsnStackElement*> m_stack;
 	int m_iSourceLine = 0;

--- a/compiler/core/asn_commentparser.h
+++ b/compiler/core/asn_commentparser.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <vector>
 #include "filetype.h"
+#include "snacc-deprecated-successor.h"
 
 std::string escapeJsonString(const std::string& input);
 enum class EElementState
@@ -21,19 +22,29 @@ enum class EElementState
 class EDeprecated
 {
 public:
-	void handleDeprecated(const std::string& strParsedLine);
+	void handleDeprecated(const std::string& strParsedLine, int lineNo = 0);
+	void tryParseSuccessorArrowLine(const std::string& strLine, int lineNo = 0);
+	void finishDeprecatedSuccessorCommentBlock(const char* szFileName, const char* szSymbolName);
 	// Type is deprecated, the value shows the time in unix time when the property has been flagged deprecated
 
-	// @deprecated [optional] 1.1.2023 [optional] comment
+	// @deprecated [optional] 1.1.2023 [optional] -> (none) | -> Symbol | -> Qualifier::Symbol
 	// e.g.
-	// @deprecated 1.1.2023 Superseeded by method xyz
+	// @deprecated 1.1.2023 -> asnKeepAlive
+	// @deprecated 1.1.2023 -> (none) optional comment
 
 	// If no time has been specified the value is set to 1
 	// The value is compared with the global gi64NoDeprecatedSymbols to validate whether the symbol shall get excluded or not for the output
 	long long i64Deprecated = 0;
-	// Deprecated comment - text that was written behing the @deprecated flag
+	// Deprecated comment - prose after canonical successor arrow (legacy prose when arrow missing)
 	std::string strDeprecated_UTF8;
 	std::string strDeprecated_ASCII;
+	// Parsed canonical @deprecated successor (warn-only validation; does not affect filtering)
+	EDeprecatedSuccessorScope successorScope = EDeprecatedSuccessorUnset;
+	std::string successorSymbol;
+	std::string successorQualifier;
+	bool bSuccessorParsed = false;
+	int iDeprecatedSuccessorInvalid = 0;
+	int iDeprecatedLine = 0;
 };
 
 class EAdded
@@ -125,7 +136,12 @@ private:
 	std::string m_strModuleName;
 };
 
-void convertCommentList(std::list<std::string>& commentList, ETypeComment* pType);
+void convertCommentList(
+	std::list<std::string>& commentList,
+	std::list<int>& commentLines,
+	ETypeComment* pType,
+	const char* szFileName,
+	const char* szSymbolName);
 
 class EAsnStackElement;
 
@@ -168,8 +184,11 @@ public:
 	void RegisterFilterSource(const char* szSourcePath, const char* szModuleName, enum EFILETYPE type);
 	// Re-parses registered sources when -nodeprecated was resolved after the first pass
 	void RebuildFilteredAsnFiles();
+	// Warn-only validation of same-file @deprecated successors after a module is fully parsed
+	void ValidateDeprecatedSuccessorsForModule(const char* szModuleName);
 
 	std::list<EAsnStackElement*> m_stack;
+	int m_iSourceLine = 0;
 
 private:
 	int ProcessLine(const char* szModuleName, const char* szLine);
@@ -229,6 +248,7 @@ public:
 
 private:
 	std::list<std::string> m_CollectComments;
+	std::list<int> m_CollectCommentLines;
 };
 
 class EAsnStackElementModule : public EAsnStackElement
@@ -242,13 +262,20 @@ public:
 
 	virtual int ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state) override;
 
-	void SetModuleProperties(const char* szTypeName, const char* szCategory, const char* szASN1ModuleName, std::list<std::string>& listComments);
+	void SetModuleProperties(
+		const char* szFileName,
+		const char* szTypeName,
+		const char* szCategory,
+		const char* szASN1ModuleName,
+		std::list<std::string>& listComments,
+		std::list<int>& listCommentLines);
 
 	bool isModuleFiltered() const;
 
 private:
 	bool m_bWaitForSemiColon = false;
 	std::list<std::string> m_CollectComments;
+	std::list<int> m_CollectCommentLines;
 
 	EModuleComment m_ModuleComment;
 };
@@ -268,10 +295,17 @@ public:
 	//{ has been found
 	bool bOpenBracketFound = false;
 
-	void SetSequenceProperties(bool bOpenBracket, const char* szTypeName, EModuleComment* pmodcomment, std::list<std::string>& listComments);
+	void SetSequenceProperties(
+		bool bOpenBracket,
+		const char* szFileName,
+		const char* szTypeName,
+		EModuleComment* pmodcomment,
+		std::list<std::string>& listComments,
+		std::list<int>& listCommentLines);
 
 	// collected comments during parsing
 	std::list<std::string> m_CollectComments;
+	std::list<int> m_CollectCommentLines;
 
 	ESequenceComment m_comment;
 	EModuleComment* m_pmodcomment;
@@ -290,6 +324,7 @@ public:
 
 	// List of comment lines before the element
 	std::list<std::string> commentsBefore;
+	std::list<int> commentsBeforeLines;
 
 	ESequenceComment m_comment;
 };
@@ -305,7 +340,12 @@ public:
 
 	virtual int ProcessLine(const char* szModuleName, const char* szRawSourceLine, std::string& szLine, std::string& szComment, EElementState& state) override;
 
-	void SetOperationProperties(const char* szTypeName, EModuleComment* pmodcomment, std::list<std::string>& listComments);
+	void SetOperationProperties(
+		const char* szFileName,
+		const char* szTypeName,
+		EModuleComment* pmodcomment,
+		std::list<std::string>& listComments,
+		std::list<int>& listCommentLines);
 
 private:
 	EOperationComment m_comment;

--- a/compiler/core/asn_comments.cpp
+++ b/compiler/core/asn_comments.cpp
@@ -34,6 +34,11 @@ extern "C"
 		parser.RebuildFilteredAsnFiles();
 	}
 
+	void ValidateAllDeprecatedSuccessors(void)
+	{
+		parser.ValidateAllDeprecatedSuccessors();
+	}
+
 	void ClearAsnCommentStateForRebuild(void)
 	{
 		gComments.mapModules.clear();

--- a/compiler/core/asn_comments.cpp
+++ b/compiler/core/asn_comments.cpp
@@ -216,6 +216,7 @@ extern "C"
 			pcomment->i64Deprecated = comment.i64Deprecated;
 			pcomment->szDeprecated = comment.strDeprecated_UTF8.c_str();
 			pcomment->iIgnoreValidation = static_cast<int>(comment.m_nIgnoreValidationMask);
+			pcomment->iDeprecatedSuccessorInvalid = comment.iDeprecatedSuccessorInvalid;
 			return 1;
 		}
 		return 0;
@@ -252,6 +253,7 @@ extern "C"
 			pcomment->i64Deprecated = comment.i64Deprecated;
 			pcomment->szDeprecated = comment.strDeprecated_ASCII.c_str();
 			pcomment->iIgnoreValidation = static_cast<int>(comment.m_nIgnoreValidationMask);
+			pcomment->iDeprecatedSuccessorInvalid = comment.iDeprecatedSuccessorInvalid;
 			return 1;
 		}
 		return 0;
@@ -280,6 +282,7 @@ extern "C"
 			pcomment->i64Deprecated = comment.i64Deprecated;
 			pcomment->szDeprecated = comment.strDeprecated_UTF8.c_str();
 			pcomment->iIgnoreValidation = static_cast<int>(comment.m_nIgnoreValidationMask);
+			pcomment->iDeprecatedSuccessorInvalid = comment.iDeprecatedSuccessorInvalid;
 			return 1;
 		}
 		return 0;
@@ -316,6 +319,7 @@ extern "C"
 			pcomment->i64Deprecated = comment.i64Deprecated;
 			pcomment->szDeprecated = comment.strDeprecated_ASCII.c_str();
 			pcomment->iIgnoreValidation = static_cast<int>(comment.m_nIgnoreValidationMask);
+			pcomment->iDeprecatedSuccessorInvalid = comment.iDeprecatedSuccessorInvalid;
 			return 1;
 		}
 		return 0;
@@ -344,6 +348,7 @@ extern "C"
 				pcomment->i64Added = comment.i64Added;
 				pcomment->i64Deprecated = comment.i64Deprecated;
 				pcomment->szDeprecated = comment.strDeprecated_UTF8.c_str();
+				pcomment->iDeprecatedSuccessorInvalid = comment.iDeprecatedSuccessorInvalid;
 				return 1;
 			}
 		}
@@ -378,6 +383,7 @@ extern "C"
 				pcomment->i64Added = comment.i64Added;
 				pcomment->i64Deprecated = comment.i64Deprecated;
 				pcomment->szDeprecated = comment.strDeprecated_ASCII.c_str();
+				pcomment->iDeprecatedSuccessorInvalid = comment.iDeprecatedSuccessorInvalid;
 				return 1;
 			}
 		}

--- a/compiler/core/asn_comments.h
+++ b/compiler/core/asn_comments.h
@@ -32,6 +32,7 @@ extern "C"
 		long long i64Deprecated;
 		const char* szDeprecated;
 		int iIgnoreValidation; /* bitmask; see snacc-validation-rules.h */
+		int iDeprecatedSuccessorInvalid;
 	} asnoperationcomment;
 
 	typedef struct _asnsequencecomment
@@ -45,6 +46,7 @@ extern "C"
 		long long i64Deprecated;
 		const char* szDeprecated;
 		int iIgnoreValidation; /* bitmask; see snacc-validation-rules.h */
+		int iDeprecatedSuccessorInvalid;
 	} asnsequencecomment;
 
 	typedef struct _asnmembercomment
@@ -55,6 +57,7 @@ extern "C"
 		long long i64Added;
 		long long i64Deprecated;
 		const char* szDeprecated;
+		int iDeprecatedSuccessorInvalid;
 	} asnmembercomment;
 
 	// Parse for Comments

--- a/compiler/core/asn_comments.h
+++ b/compiler/core/asn_comments.h
@@ -66,6 +66,8 @@ extern "C"
 	extern void RegisterFilterSourceFile(const char* szSourcePath, const char* szModuleName, enum EFILETYPE type);
 	extern void RebuildFilteredAsnFilesIfNeeded(void);
 	extern void ClearAsnCommentStateForRebuild(void);
+	/** Warn-only check of qualified @deprecated successors against loaded modules. */
+	extern void ValidateAllDeprecatedSuccessors(void);
 
 	// Get LogFilter Attributes (if any) call recurring until it returns 0
 	extern const char* GetFirstModuleLogFileFilter(const char* szModuleName);

--- a/compiler/core/snacc-deprecated-successor.cpp
+++ b/compiler/core/snacc-deprecated-successor.cpp
@@ -143,6 +143,31 @@ void EmitDeprecatedSuccessorNotInFileWarning(
 		pszSuccessor);
 }
 
+void EmitDeprecatedSuccessorNotInModuleWarning(
+	const char* pszFileName,
+	int lineNo,
+	const char* pszSymbolName,
+	const char* pszSuccessorQualifier,
+	const char* pszSuccessorSymbol,
+	const char* pszResolvedModuleName)
+{
+	const char* pszFile = pszFileName ? pszFileName : "<unknown>";
+	const char* pszSymbol = pszSymbolName ? pszSymbolName : "<unknown>";
+	const char* pszQualifier = pszSuccessorQualifier ? pszSuccessorQualifier : "<unknown>";
+	const char* pszSuccessor = pszSuccessorSymbol ? pszSuccessorSymbol : "<unknown>";
+	const char* pszModule = pszResolvedModuleName ? pszResolvedModuleName : "<unknown>";
+	const int reportedLine = lineNo > 0 ? lineNo : 1;
+	fprintf(
+		stderr,
+		"warning: %s:%d %s: @deprecated successor '%s::%s' is not defined in loaded module '%s'\n",
+		pszFile,
+		reportedLine,
+		pszSymbol,
+		pszQualifier,
+		pszSuccessor,
+		pszModule);
+}
+
 extern "C" void PrintDeprecatedSuccessorHelp(FILE* fp)
 {
 	if (!fp)
@@ -154,5 +179,8 @@ extern "C" void PrintDeprecatedSuccessorHelp(FILE* fp)
 	fprintf(fp, "     -- @deprecated Day.Month.Year -> OtherModule::Symbol\n");
 	fprintf(fp, "     -- @deprecated Day.Month.Year -> OtherRepo::Symbol\n");
 	fprintf(fp, "     Arrow may be on the @deprecated line or the next -- comment line above the definition.\n");
+	fprintf(fp, "     Unqualified successors must exist in the same file; qualified successors are checked when the\n");
+	fprintf(fp, "     target module is part of the current esnacc invocation (UCWeb:: maps to loaded EUCWeb_* modules).\n");
+	fprintf(fp, "     Validation applies to operations and SEQUENCE/CHOICE types only, not SEQUENCE or ENUMERATED members.\n");
 	fprintf(fp, "     Legacy prose (see Symbol, moved to, file paths) without -> triggers a warning.\n");
 }

--- a/compiler/core/snacc-deprecated-successor.cpp
+++ b/compiler/core/snacc-deprecated-successor.cpp
@@ -1,0 +1,158 @@
+#include "snacc-deprecated-successor.h"
+
+#include "../../c-lib/include/asn-config.h"
+#include <cctype>
+#include <cstring>
+#include <string>
+
+namespace
+{
+	std::string trimLocal(const std::string& value)
+	{
+		size_t start = 0;
+		while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start])))
+			++start;
+		size_t end = value.size();
+		while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1])))
+			--end;
+		return value.substr(start, end - start);
+	}
+
+	bool startsWith(const std::string& value, const char* pszPrefix)
+	{
+		const char* pszSafe = pszPrefix ? pszPrefix : "";
+		return value.rfind(pszSafe, 0) == 0;
+	}
+
+	bool parseArrowTarget(const std::string& arrowRemainder, DeprecatedSuccessorFields& fields, std::string& proseAfter)
+	{
+		std::string targetPart = trimLocal(arrowRemainder);
+		if (startsWith(targetPart, "(none)"))
+		{
+			fields.scope = EDeprecatedSuccessorNone;
+			fields.symbol.clear();
+			fields.qualifier.clear();
+			proseAfter = trimLocal(targetPart.substr(6));
+			fields.proseAfter = proseAfter;
+			fields.parsed = true;
+			++fields.arrowCount;
+			return true;
+		}
+
+		std::string targetToken;
+		const size_t spacePos = targetPart.find(' ');
+		if (spacePos != std::string::npos)
+		{
+			targetToken = targetPart.substr(0, spacePos);
+			proseAfter = trimLocal(targetPart.substr(spacePos + 1));
+		}
+		else
+			targetToken = targetPart;
+
+		if (targetToken.empty())
+			return false;
+
+		const size_t qualifierPos = targetToken.find("::");
+		if (qualifierPos == std::string::npos)
+		{
+			fields.scope = EDeprecatedSuccessorSameFile;
+			fields.symbol = targetToken;
+			fields.qualifier.clear();
+		}
+		else
+		{
+			fields.scope = EDeprecatedSuccessorQualified;
+			fields.qualifier = targetToken.substr(0, qualifierPos);
+			fields.symbol = targetToken.substr(qualifierPos + 2);
+		}
+
+		if (fields.symbol.empty())
+			return false;
+
+		fields.proseAfter = proseAfter;
+		fields.parsed = true;
+		++fields.arrowCount;
+		return true;
+	}
+} // namespace
+
+bool ParseDeprecatedSuccessorArrowLine(const std::string& trimmedLine, DeprecatedSuccessorFields& fields)
+{
+	std::string proseAfter;
+	if (!startsWith(trimmedLine, "->"))
+		return false;
+	return parseArrowTarget(trimmedLine.substr(2), fields, proseAfter);
+}
+
+bool FindAndParseDeprecatedSuccessorInText(const std::string& text, DeprecatedSuccessorFields& fields, std::string& textWithoutSuccessor)
+{
+	const size_t arrowPos = text.find("->");
+	if (arrowPos == std::string::npos)
+	{
+		textWithoutSuccessor = text;
+		return false;
+	}
+
+	std::string proseAfter;
+	if (!parseArrowTarget(text.substr(arrowPos + 2), fields, proseAfter))
+	{
+		textWithoutSuccessor = text;
+		return false;
+	}
+
+	textWithoutSuccessor = trimLocal(text.substr(0, arrowPos));
+	if (!proseAfter.empty())
+	{
+		if (!textWithoutSuccessor.empty())
+			textWithoutSuccessor += " ";
+		textWithoutSuccessor += proseAfter;
+	}
+	textWithoutSuccessor = trimLocal(textWithoutSuccessor);
+	return true;
+}
+
+void EmitDeprecatedSuccessorMissingWarning(const char* pszFileName, int lineNo, const char* pszSymbolName)
+{
+	const char* pszFile = pszFileName ? pszFileName : "<unknown>";
+	const char* pszSymbol = pszSymbolName ? pszSymbolName : "<unknown>";
+	const int reportedLine = lineNo > 0 ? lineNo : 1;
+	fprintf(
+		stderr,
+		"warning: %s:%d %s: @deprecated missing canonical successor (expected -> (none), -> Symbol, or -> Repo::Symbol)\n",
+		pszFile,
+		reportedLine,
+		pszSymbol);
+}
+
+void EmitDeprecatedSuccessorNotInFileWarning(
+	const char* pszFileName,
+	int lineNo,
+	const char* pszSymbolName,
+	const char* pszSuccessorSymbol)
+{
+	const char* pszFile = pszFileName ? pszFileName : "<unknown>";
+	const char* pszSymbol = pszSymbolName ? pszSymbolName : "<unknown>";
+	const char* pszSuccessor = pszSuccessorSymbol ? pszSuccessorSymbol : "<unknown>";
+	const int reportedLine = lineNo > 0 ? lineNo : 1;
+	fprintf(
+		stderr,
+		"warning: %s:%d %s: @deprecated successor '%s' is not defined in this file\n",
+		pszFile,
+		reportedLine,
+		pszSymbol,
+		pszSuccessor);
+}
+
+extern "C" void PrintDeprecatedSuccessorHelp(FILE* fp)
+{
+	if (!fp)
+		return;
+
+	fprintf(fp, "   @deprecated canonical successor (warn-only; compilation continues):\n");
+	fprintf(fp, "     -- @deprecated Day.Month.Year -> (none) [optional comment]\n");
+	fprintf(fp, "     -- @deprecated Day.Month.Year -> SymbolInThisFile\n");
+	fprintf(fp, "     -- @deprecated Day.Month.Year -> OtherModule::Symbol\n");
+	fprintf(fp, "     -- @deprecated Day.Month.Year -> OtherRepo::Symbol\n");
+	fprintf(fp, "     Arrow may be on the @deprecated line or the next -- comment line above the definition.\n");
+	fprintf(fp, "     Legacy prose (see Symbol, moved to, file paths) without -> triggers a warning.\n");
+}

--- a/compiler/core/snacc-deprecated-successor.h
+++ b/compiler/core/snacc-deprecated-successor.h
@@ -1,0 +1,48 @@
+#ifndef SNACC_DEPRECATED_SUCCESSOR_H
+#define SNACC_DEPRECATED_SUCCESSOR_H
+
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	/** Prints canonical @deprecated successor syntax for esnacc7 -h. */
+	void PrintDeprecatedSuccessorHelp(FILE* fp);
+
+#ifdef __cplusplus
+}
+
+#include <string>
+
+typedef enum EDeprecatedSuccessorScope
+{
+	EDeprecatedSuccessorUnset = 0,
+	EDeprecatedSuccessorNone = 1,
+	EDeprecatedSuccessorSameFile = 2,
+	EDeprecatedSuccessorQualified = 3
+} EDeprecatedSuccessorScope;
+
+struct DeprecatedSuccessorFields
+{
+	int arrowCount = 0;
+	bool parsed = false;
+	EDeprecatedSuccessorScope scope = EDeprecatedSuccessorUnset;
+	std::string symbol;
+	std::string qualifier;
+	std::string proseAfter;
+};
+
+bool ParseDeprecatedSuccessorArrowLine(const std::string& trimmedLine, DeprecatedSuccessorFields& fields);
+bool FindAndParseDeprecatedSuccessorInText(const std::string& text, DeprecatedSuccessorFields& fields, std::string& textWithoutSuccessor);
+void EmitDeprecatedSuccessorMissingWarning(const char* pszFileName, int lineNo, const char* pszSymbolName);
+void EmitDeprecatedSuccessorNotInFileWarning(
+	const char* pszFileName,
+	int lineNo,
+	const char* pszSymbolName,
+	const char* pszSuccessorSymbol);
+#endif
+
+#endif /* SNACC_DEPRECATED_SUCCESSOR_H */

--- a/compiler/core/snacc-deprecated-successor.h
+++ b/compiler/core/snacc-deprecated-successor.h
@@ -43,6 +43,13 @@ void EmitDeprecatedSuccessorNotInFileWarning(
 	int lineNo,
 	const char* pszSymbolName,
 	const char* pszSuccessorSymbol);
+void EmitDeprecatedSuccessorNotInModuleWarning(
+	const char* pszFileName,
+	int lineNo,
+	const char* pszSymbolName,
+	const char* pszSuccessorQualifier,
+	const char* pszSuccessorSymbol,
+	const char* pszResolvedModuleName);
 #endif
 
 #endif /* SNACC_DEPRECATED_SUCCESSOR_H */

--- a/compiler/core/snacc.c
+++ b/compiler/core/snacc.c
@@ -62,6 +62,7 @@ char* bVDAGlobalDLLExport = (char*)0;
 #include "time_helpers.h"
 #include "interface_baseline.h"
 #include "module_version_emit.h"
+#include "snacc-deprecated-successor.h"
 #if META
 #include "meta.h"
 #endif
@@ -260,6 +261,7 @@ void Usage PARAMS((prgName, fp), char* prgName _AND_ FILE* fp)
 	fprintf(fp, "   @deprecated exempts a type/operation from all checks below. @ignorevalidation exempts only the named rules (see below).\n");
 	PrintValidationLevelHelp(fp);
 	PrintIgnoreValidationRuleNames(fp);
+	PrintDeprecatedSuccessorHelp(fp);
 	fprintf(fp, "  -utf8   write output files with UTF-8 encoding (default: system codepage / Windows-1252)\n");
 	fprintf(fp, "  -utf8bom   write a UTF-8 BOM at the start of each output file (implies -utf8)\n");
 	fprintf(fp, "  -h   prints this msg\n");

--- a/compiler/core/snacc.c
+++ b/compiler/core/snacc.c
@@ -184,9 +184,6 @@ int giValidationLevel = 0xffffffff;
 // Write comments to the target files on true (parsing is always enabled)
 int giWriteComments = 0;
 
-// Write a combined version file
-int genVersionFile = FALSE;
-
 // Defines whether we write commonsJS or ESM typescript code
 int genTSESMCode = FALSE;
 
@@ -263,7 +260,6 @@ void Usage PARAMS((prgName, fp), char* prgName _AND_ FILE* fp)
 	fprintf(fp, "   @deprecated exempts a type/operation from all checks below. @ignorevalidation exempts only the named rules (see below).\n");
 	PrintValidationLevelHelp(fp);
 	PrintIgnoreValidationRuleNames(fp);
-	fprintf(fp, "  -versionfile - the compiler writes a combined Asn1InterfaceVersion file for the compile scope\n");
 	fprintf(fp, "  -utf8   write output files with UTF-8 encoding (default: system codepage / Windows-1252)\n");
 	fprintf(fp, "  -utf8bom   write a UTF-8 BOM at the start of each output file (implies -utf8)\n");
 	fprintf(fp, "  -h   prints this msg\n");
@@ -509,12 +505,7 @@ int main PARAMS((argc, argv), int argc _AND_ char** argv)
 					}
 					break;
 				case 'v':
-					if (strcmp(argument + 1, "versionfile") == 0)
-					{
-						genVersionFile = 1;
-						currArg++;
-					}
-					else if (strcmp(argument + 1, "v") == 0)
+					if (strcmp(argument + 1, "v") == 0)
 					{
 						genValueCode = TRUE;
 						currArg++;
@@ -1592,47 +1583,6 @@ void GenCxxCode(ModuleList* allMods, long longJmpVal, int genTypes, int genValue
 			fprintf(meta.srcfp, "//\n");
 		}
 #endif
-	}
-
-	if (gMajorInterfaceVersion >= 0 && genVersionFile)
-	{
-		FILE* versionFile = NULL;
-		char* szVersionFile = MakeFileName("Asn1InterfaceVersion.h", "");
-		if (fopen_s(&versionFile, szVersionFile, "wt") != 0 || versionFile == NULL)
-			perror("fopen");
-		else
-		{
-			WriteUTF8BOM(versionFile);
-			long long lMaxPatchVersion = GetMaxModulePatchVersion();
-			write_snacc_header(versionFile, "// ");
-			fprintf(versionFile, "\n");
-			fprintf(versionFile, "// clang-format off\n\n");
-			fprintf(versionFile, "#ifndef ASN1_INTERFACE_VERSION_H\n");
-			fprintf(versionFile, "#define ASN1_INTERFACE_VERSION_H\n\n");
-			fprintf(versionFile, "#ifndef NO_NAMESPACE\n");
-			fprintf(versionFile, "namespace SNACC\n");
-			fprintf(versionFile, "{\n");
-			fprintf(versionFile, "#endif\n\n");
-
-			fprintf(versionFile, "struct Asn1InterfaceVersion\n");
-			fprintf(versionFile, "{\n");
-			EmitAnnotatedModuleVersionFields(
-				versionFile,
-				ModuleVersionEmitCppInterfaceVersionStruct,
-				NULL,
-				"\t",
-				gMajorInterfaceVersion,
-				lMaxPatchVersion);
-			fprintf(versionFile, "};\n\n");
-
-			fprintf(versionFile, "#ifndef NO_NAMESPACE\n");
-			fprintf(versionFile, "}\n");
-			fprintf(versionFile, "#endif\n\n");
-
-			fprintf(versionFile, "#endif");
-			fclose(versionFile);
-		}
-		free(szVersionFile);
 	}
 
 	FOR_EACH_LIST_ELMT(currMod, allMods)

--- a/compiler/core/snacc.c
+++ b/compiler/core/snacc.c
@@ -951,6 +951,7 @@ int main PARAMS((argc, argv), int argc _AND_ char** argv)
 
 	ResolveInterfaceBaselineAfterParse();
 	RebuildFilteredAsnFilesIfNeeded();
+	ValidateAllDeprecatedSuccessors();
 
 	// If we are filtering we now just need to write the contents of the file parser
 	if (gFilterASN1Files)

--- a/compiler/tests/CMakeLists.txt
+++ b/compiler/tests/CMakeLists.txt
@@ -34,6 +34,35 @@ gtest_discover_tests(compiler-cli-tests
 		ENVIRONMENT "ESNACC_EXECUTABLE=$<TARGET_FILE:compiler>"
 )
 
+add_executable(deprecated-successor-tests
+	deprecated_successor_tests.cpp
+	"${CMAKE_SOURCE_DIR}/compiler/core/snacc-deprecated-successor.cpp"
+)
+target_include_directories(deprecated-successor-tests PRIVATE
+	"${CMAKE_SOURCE_DIR}"
+	"${CMAKE_SOURCE_DIR}/compiler/core"
+	"${CMAKE_SOURCE_DIR}/c-lib/include"
+)
+target_link_libraries(deprecated-successor-tests PRIVATE GTest::gtest_main c-lib)
+gtest_discover_tests(deprecated-successor-tests)
+
+add_executable(deprecated-successor-cli-tests
+	deprecated_successor_cli_tests.cpp
+	test_support.cpp
+	test_work_dir.cpp
+)
+target_include_directories(deprecated-successor-cli-tests PRIVATE
+	"${CMAKE_CURRENT_BINARY_DIR}"
+	"${CMAKE_SOURCE_DIR}"
+	"${CMAKE_SOURCE_DIR}/compiler/core"
+)
+target_link_libraries(deprecated-successor-cli-tests PRIVATE GTest::gtest_main)
+add_dependencies(deprecated-successor-cli-tests compiler)
+gtest_discover_tests(deprecated-successor-cli-tests
+	PROPERTIES
+		ENVIRONMENT "ESNACC_EXECUTABLE=$<TARGET_FILE:compiler>"
+)
+
 add_executable(interface-baseline-tests
 	interface_baseline_tests.cpp
 	"${CMAKE_CURRENT_SOURCE_DIR}/../core/interface_baseline.c"

--- a/compiler/tests/deprecated_successor_cli_tests.cpp
+++ b/compiler/tests/deprecated_successor_cli_tests.cpp
@@ -12,6 +12,16 @@ std::filesystem::path InputModulePath(const TestWorkDir& workDir)
 	return workDir.path() / "DeprecatedSuccessor_Test.asn1";
 }
 
+std::filesystem::path RefModulePath(const TestWorkDir& workDir)
+{
+	return workDir.path() / "DeprecatedSuccessor_Ref.asn1";
+}
+
+std::filesystem::path UcWebModulePath(const TestWorkDir& workDir)
+{
+	return workDir.path() / "EUCWeb_Successor_Test.asn1";
+}
+
 ProcessResult RunEsnaccOnDeprecatedSuccessorFixture(const TestWorkDir& workDir)
 {
 	std::filesystem::create_directories(workDir.path() / "out");
@@ -19,6 +29,30 @@ ProcessResult RunEsnaccOnDeprecatedSuccessorFixture(const TestWorkDir& workDir)
 		"-C",
 		"-o",
 		(workDir.path() / "out").string(),
+		InputModulePath(workDir).string()};
+	return RunProcess(ResolveEsnaccExecutable(), args, workDir.path());
+}
+
+ProcessResult RunEsnaccOnDeprecatedSuccessorFixtureWithRefs(const TestWorkDir& workDir)
+{
+	std::filesystem::create_directories(workDir.path() / "out");
+	std::vector<std::string> args = {
+		"-C",
+		"-o",
+		(workDir.path() / "out").string(),
+		RefModulePath(workDir).string(),
+		InputModulePath(workDir).string()};
+	return RunProcess(ResolveEsnaccExecutable(), args, workDir.path());
+}
+
+ProcessResult RunEsnaccOnDeprecatedSuccessorFixtureWithUcWeb(const TestWorkDir& workDir)
+{
+	std::filesystem::create_directories(workDir.path() / "out");
+	std::vector<std::string> args = {
+		"-C",
+		"-o",
+		(workDir.path() / "out").string(),
+		UcWebModulePath(workDir).string(),
 		InputModulePath(workDir).string()};
 	return RunProcess(ResolveEsnaccExecutable(), args, workDir.path());
 }
@@ -59,4 +93,51 @@ TEST(DeprecatedSuccessorCliTest, LegacyOperationWarnsWithSymbolNameInMessage)
 	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixture(workDir);
 	ASSERT_EQ(result.exitCode, 0) << result.output;
 	EXPECT_NE(result.output.find("asnLegacyProse: @deprecated missing canonical successor"), std::string::npos) << result.output;
+}
+
+TEST(DeprecatedSuccessorCliTest, LoadedCrossModuleSuccessorProducesNoWarning)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Ref.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixtureWithRefs(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_EQ(result.output.find("asnValidCrossModule: @deprecated successor"), std::string::npos) << result.output;
+}
+
+TEST(DeprecatedSuccessorCliTest, MissingLoadedCrossModuleSuccessorWarns)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Ref.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixtureWithRefs(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_NE(result.output.find("asnInvalidCrossModule"), std::string::npos) << result.output;
+	EXPECT_NE(result.output.find("DeprecatedSuccessor_Ref::asnMissingInRef"), std::string::npos) << result.output;
+	EXPECT_NE(result.output.find("is not defined in loaded module"), std::string::npos) << result.output;
+}
+
+TEST(DeprecatedSuccessorCliTest, LoadedUcWebSuccessorProducesNoWarning)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+	workDir.CopyFixture(FixtureDirectory() / "EUCWeb_Successor_Test.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixtureWithUcWeb(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_EQ(result.output.find("asnValidExternal: @deprecated successor"), std::string::npos) << result.output;
+}
+
+TEST(DeprecatedSuccessorCliTest, EnumMemberDeprecationSkipsSuccessorValidation)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixture(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_EQ(result.output.find("eLegacyEnumValue"), std::string::npos) << result.output;
+	EXPECT_EQ(result.output.find("eValidEnumValue"), std::string::npos) << result.output;
+	EXPECT_EQ(result.output.find("AsnEnumMemberDeprecationEnum"), std::string::npos) << result.output;
 }

--- a/compiler/tests/deprecated_successor_cli_tests.cpp
+++ b/compiler/tests/deprecated_successor_cli_tests.cpp
@@ -1,0 +1,62 @@
+#include "test_support.h"
+#include "test_work_dir.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+namespace
+{
+std::filesystem::path InputModulePath(const TestWorkDir& workDir)
+{
+	return workDir.path() / "DeprecatedSuccessor_Test.asn1";
+}
+
+ProcessResult RunEsnaccOnDeprecatedSuccessorFixture(const TestWorkDir& workDir)
+{
+	std::filesystem::create_directories(workDir.path() / "out");
+	std::vector<std::string> args = {
+		"-C",
+		"-o",
+		(workDir.path() / "out").string(),
+		InputModulePath(workDir).string()};
+	return RunProcess(ResolveEsnaccExecutable(), args, workDir.path());
+}
+} // namespace
+
+TEST(DeprecatedSuccessorCliTest, ValidCanonicalNotationProducesNoSuccessorWarnings)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixture(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_EQ(result.output.find("asnValidNone: @deprecated missing canonical successor"), std::string::npos) << result.output;
+	EXPECT_EQ(result.output.find("asnValidSameFile: @deprecated missing canonical successor"), std::string::npos) << result.output;
+	EXPECT_EQ(result.output.find("asnValidExternal: @deprecated missing canonical successor"), std::string::npos) << result.output;
+	EXPECT_EQ(result.output.find("asnSuccessorOnNextLine: @deprecated missing canonical successor"), std::string::npos) << result.output;
+	EXPECT_EQ(result.output.find("asnValidSameFile: @deprecated successor"), std::string::npos) << result.output;
+}
+
+TEST(DeprecatedSuccessorCliTest, LegacyAndMissingSuccessorsWarnWithoutFailingCompile)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixture(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_NE(result.output.find("asnLegacyProse"), std::string::npos) << result.output;
+	EXPECT_NE(result.output.find("asnMissingSuccessor"), std::string::npos) << result.output;
+	EXPECT_NE(result.output.find("is not defined in this file"), std::string::npos) << result.output;
+	EXPECT_NE(result.output.find("missing canonical successor"), std::string::npos) << result.output;
+}
+
+TEST(DeprecatedSuccessorCliTest, LegacyOperationWarnsWithSymbolNameInMessage)
+{
+	TestWorkDir workDir;
+	workDir.CopyFixture(FixtureDirectory() / "DeprecatedSuccessor_Test.asn1");
+
+	const ProcessResult result = RunEsnaccOnDeprecatedSuccessorFixture(workDir);
+	ASSERT_EQ(result.exitCode, 0) << result.output;
+	EXPECT_NE(result.output.find("asnLegacyProse: @deprecated missing canonical successor"), std::string::npos) << result.output;
+}

--- a/compiler/tests/deprecated_successor_tests.cpp
+++ b/compiler/tests/deprecated_successor_tests.cpp
@@ -1,0 +1,57 @@
+#include "snacc-deprecated-successor.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace
+{
+DeprecatedSuccessorFields parseArrow(const char* pszLine)
+{
+	DeprecatedSuccessorFields fields;
+	EXPECT_TRUE(ParseDeprecatedSuccessorArrowLine(pszLine ? pszLine : "", fields));
+	return fields;
+}
+} // namespace
+
+TEST(DeprecatedSuccessorParserTest, ParsesNoneWithOptionalComment)
+{
+	const DeprecatedSuccessorFields fields = parseArrow("-> (none) optional comment");
+	EXPECT_EQ(fields.scope, EDeprecatedSuccessorNone);
+	EXPECT_TRUE(fields.symbol.empty());
+	EXPECT_EQ(fields.proseAfter, "optional comment");
+}
+
+TEST(DeprecatedSuccessorParserTest, ParsesSameFileSymbol)
+{
+	const DeprecatedSuccessorFields fields = parseArrow("-> asnResetUserAbsentState");
+	EXPECT_EQ(fields.scope, EDeprecatedSuccessorSameFile);
+	EXPECT_EQ(fields.symbol, "asnResetUserAbsentState");
+	EXPECT_TRUE(fields.qualifier.empty());
+}
+
+TEST(DeprecatedSuccessorParserTest, ParsesQualifiedSymbol)
+{
+	const DeprecatedSuccessorFields fields = parseArrow("-> UCWeb::asnGetTime");
+	EXPECT_EQ(fields.scope, EDeprecatedSuccessorQualified);
+	EXPECT_EQ(fields.qualifier, "UCWeb");
+	EXPECT_EQ(fields.symbol, "asnGetTime");
+}
+
+TEST(DeprecatedSuccessorParserTest, FindsArrowAfterDateRemainder)
+{
+	DeprecatedSuccessorFields fields;
+	std::string remainder;
+	EXPECT_TRUE(FindAndParseDeprecatedSuccessorInText("22.08.2024 -> asnFoo", fields, remainder));
+	EXPECT_EQ(fields.scope, EDeprecatedSuccessorSameFile);
+	EXPECT_EQ(fields.symbol, "asnFoo");
+	EXPECT_EQ(remainder, "22.08.2024");
+}
+
+TEST(DeprecatedSuccessorParserTest, RejectsLegacyProseWithoutArrow)
+{
+	DeprecatedSuccessorFields fields;
+	std::string remainder;
+	EXPECT_FALSE(FindAndParseDeprecatedSuccessorInText("see asnFoo", fields, remainder));
+	EXPECT_FALSE(ParseDeprecatedSuccessorArrowLine("see asnFoo", fields));
+}

--- a/compiler/tests/fixtures/Baseline_Test.asn1
+++ b/compiler/tests/fixtures/Baseline_Test.asn1
@@ -5,7 +5,7 @@ DEFINITIONS
 IMPLICIT TAGS ::=
 BEGIN
 
--- @deprecated 15.06.2024
+-- @deprecated 15.06.2024 -> (none)
 asnDeprecatedOp OPERATION
 	ARGUMENT	arg NULL
 	RESULT		res NULL

--- a/compiler/tests/fixtures/DeprecatedSuccessor_Ref.asn1
+++ b/compiler/tests/fixtures/DeprecatedSuccessor_Ref.asn1
@@ -1,0 +1,13 @@
+DeprecatedSuccessor-Ref
+	{ 1 3 6 1 4 1 10924 9999 97 }
+
+DEFINITIONS
+IMPLICIT TAGS ::=
+BEGIN
+
+asnValidTarget OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9001
+
+END

--- a/compiler/tests/fixtures/DeprecatedSuccessor_Test.asn1
+++ b/compiler/tests/fixtures/DeprecatedSuccessor_Test.asn1
@@ -1,0 +1,45 @@
+DeprecatedSuccessor-Test
+	{ 1 3 6 1 4 1 10924 9999 98 }
+
+DEFINITIONS
+IMPLICIT TAGS ::=
+BEGIN
+
+-- @deprecated 01.01.2024 -> (none)
+asnValidNone OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9101
+
+-- @deprecated 02.01.2024 -> asnValidSameFile
+asnValidSameFile OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9102
+
+-- @deprecated 03.01.2024 -> UCWeb::asnGetTime
+asnValidExternal OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9103
+
+-- @deprecated 04.01.2024 see asnValidSameFile
+asnLegacyProse OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9104
+
+-- @deprecated 05.01.2024 -> asnMissingSymbol
+asnMissingSuccessor OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9105
+
+-- @deprecated 06.01.2024
+-- -> asnValidSameFile
+asnSuccessorOnNextLine OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9106
+
+END

--- a/compiler/tests/fixtures/DeprecatedSuccessor_Test.asn1
+++ b/compiler/tests/fixtures/DeprecatedSuccessor_Test.asn1
@@ -42,4 +42,22 @@ asnSuccessorOnNextLine OPERATION
 	RESULT		res NULL
 ::= 9106
 
+-- @deprecated 07.01.2024 -> DeprecatedSuccessor_Ref::asnValidTarget
+asnValidCrossModule OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9107
+
+-- @deprecated 08.01.2024 -> DeprecatedSuccessor_Ref::asnMissingInRef
+asnInvalidCrossModule OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9108
+
+AsnEnumMemberDeprecationEnum ::= ENUMERATED
+{
+	eLegacyEnumValue(1),	-- @deprecated 10.01.2024 legacy prose without canonical arrow
+	eValidEnumValue(2)	-- @deprecated 11.01.2024 -> (none)
+}
+
 END

--- a/compiler/tests/fixtures/EUCWeb_Successor_Test.asn1
+++ b/compiler/tests/fixtures/EUCWeb_Successor_Test.asn1
@@ -1,0 +1,13 @@
+EUCWeb-Successor-Test
+	{ 1 3 6 1 4 1 10924 9999 96 }
+
+DEFINITIONS
+IMPLICIT TAGS ::=
+BEGIN
+
+asnGetTime OPERATION
+	ARGUMENT	arg NULL
+	RESULT		res NULL
+::= 9601
+
+END

--- a/compiler/tests/test_support.cpp
+++ b/compiler/tests/test_support.cpp
@@ -39,13 +39,19 @@ ProcessResult RunProcess(const std::filesystem::path& executable, const std::vec
 	for (const std::string& arg : args)
 		command << ' ' << QuoteArgument(arg);
 
+	const std::filesystem::path outputFile = workingDirectory / ".esnacc_process_output.txt";
+	std::error_code removeEc;
+
 #ifdef _WIN32
-	std::string commandLine = "cd /d " + QuoteArgument(workingDirectory.string()) + " && " + command.str() + " 2>&1";
+	std::string commandLine = "cd /d " + QuoteArgument(workingDirectory.string()) + " && " + command.str() + " > " + QuoteArgument(outputFile.string()) + " 2>&1";
 	result.exitCode = std::system(commandLine.c_str());
 #else
-	std::string commandLine = "cd " + QuoteArgument(workingDirectory.string()) + " && " + command.str() + " 2>&1";
+	std::string commandLine = "cd " + QuoteArgument(workingDirectory.string()) + " && " + command.str() + " > " + QuoteArgument(outputFile.string()) + " 2>&1";
 	result.exitCode = std::system(commandLine.c_str());
 #endif
+
+	result.output = ReadFileToString(outputFile);
+	std::filesystem::remove(outputFile, removeEc);
 
 	return result;
 }

--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -4,6 +4,7 @@
 /*! Requires std::map */
 #include <set>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <functional>
 #include <string>
@@ -115,25 +116,39 @@ typedef std::map<long, std::unique_ptr<SnaccROSEPendingOperation>> SnaccROSEPend
 
 class SnaccROSEBase;
 
-// Helper class for OperationID / Name lookup
-// All generated interfaces register their OperationIDs in this class
-class SnaccRoseOperationLookup
+/*! Per-operation @added / @deprecated metadata (unix seconds; 0 = not annotated). */
+struct SnaccOpVersionInfo
 {
-public:
-	static const char* LookUpName(unsigned int uiOpID);
-	static unsigned int LookUpID(const char* szOpName);
-	static void RegisterOperation(unsigned int uiOpID, const char* szOpName, unsigned int uiInterfaceID);
-	static unsigned int LookUpInterfaceID(unsigned int uiOpID);
-	// check if at least one Operation has been registerd
-	static bool Initialized();
-	// Cleanup all registered Operations (can be called during shutdown)
-	static void CleanUp();
-
-private:
-	static inline std::map<std::string, unsigned int> m_mapOpToID;
-	static inline std::map<unsigned int, std::string> m_mapIDToOp;
-	static inline std::map<unsigned int, unsigned int> m_mapIDToInterface;
+	long long m_llAddedUnix = 0;
+	long long m_llDeprecatedUnix = 0;
 };
+
+/*! Loaded module snapshot for negotiate / introspection on one ROSE stub instance. */
+struct SnaccLoadedModuleInfo
+{
+	std::string m_strModuleName;
+	std::string m_strVersion;
+	std::unordered_map<unsigned int, SnaccOpVersionInfo> m_invokes;
+	std::unordered_map<unsigned int, SnaccOpVersionInfo> m_events;
+};
+
+using SnaccLoadedModuleMap = std::unordered_map<std::string, SnaccLoadedModuleInfo>;
+
+class SnaccROSESender;
+
+/*! Registers one ROSE operation on a stub sender (generated code entry point). */
+void SnaccRoseRegisterOperationOnSender(
+	SnaccROSESender* pSender,
+	unsigned int uiOpID,
+	const char* szOpName,
+	unsigned int uiInterfaceID,
+	const char* szModuleName,
+	long long llAddedUnix,
+	long long llDeprecatedUnix,
+	bool bIsEvent);
+
+/*! Registers module version metadata on a stub sender (generated code entry point). */
+void SnaccRoseRegisterModuleVersionOnSender(SnaccROSESender* pSender, const char* szModuleName, const char* szVersion);
 
 #define SNACC_TE_BER SNACC::TransportEncoding::BER
 #define SNACC_TE_JSON SNACC::TransportEncoding::JSON
@@ -223,6 +238,43 @@ public:
 
 	/* Retrieve the log level - do we need to log something */
 	virtual SNACC::EAsnLogLevel GetLogLevel(const bool bOutbound) override = 0;
+
+	/*! Registers module version wire string (MODULE_VERSION) for this stub instance. */
+	void RegisterModuleVersion(const char* szModuleName, const char* szVersion);
+
+	/*! Registers one ROSE operation (invoke or event) on this stub instance. */
+	void RegisterOperation(
+		unsigned int uiOpID,
+		const char* szOpName,
+		unsigned int uiInterfaceID,
+		const char* szModuleName,
+		long long llAddedUnix,
+		long long llDeprecatedUnix,
+		bool bIsEvent);
+
+	/*! Removes one operation from this stub registry. */
+	void UnregisterOperation(unsigned int uiOpID);
+
+	/*! Removes a module and all of its operations from this stub registry. */
+	void UnregisterModule(const char* szModuleName);
+
+	/*! Clears all module and operation registrations on this stub (tests / shutdown). */
+	void ClearRegisteredOperations();
+
+	/*! True when at least one operation is registered on this stub. */
+	bool HasRegisteredOperations() const;
+
+	/*! Snapshot of modules and operations registered on this stub. */
+	const SnaccLoadedModuleMap& GetLoadedModules() const;
+
+	/*! Resolves operation name from operation id on this stub. */
+	const char* LookUpName(unsigned int uiOpID) const;
+
+	/*! Resolves operation id from operation name on this stub. */
+	unsigned int LookUpID(const char* szOpName) const;
+
+	/*! Resolves generated interface id (m_iid) from operation id on this stub. */
+	unsigned int LookUpInterfaceID(unsigned int uiOpID) const;
 
 	/*! Writes JSON encoded log messages to the log file
 		bOutbound = true in case the log entry is related to an outbound message
@@ -410,7 +462,7 @@ private:
 		unsigned int m_uiOperationID = 0;
 		std::string m_strOperationName;
 
-		static std::optional<InboundInvokeRejectContext> TryFrom(const SNACC::ROSEMessage& message);
+		static std::optional<InboundInvokeRejectContext> TryFrom(const SNACC::ROSEMessage& message, const SnaccROSEBase& stub);
 		bool CanSendReject() const;
 		const char* OperationNameCStr() const;
 	};
@@ -508,6 +560,12 @@ private:
 	 * ctx - contextual data for the invoke
 	 */
 	long Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext& ctx, size_t* pstRequestData = nullptr);
+
+	std::map<std::string, unsigned int> m_mapOpToID;
+	std::map<unsigned int, std::string> m_mapIDToOp;
+	std::map<unsigned int, unsigned int> m_mapIDToInterface;
+	SnaccLoadedModuleMap m_loadedModules;
+	std::unordered_map<unsigned int, std::pair<std::string, bool>> m_mapIDToModuleKind;
 };
 
 #endif //_SnaccROSEBase_h_

--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -119,8 +119,8 @@ class SnaccROSEBase;
 /*! Per-operation @added / @deprecated metadata (unix seconds; 0 = not annotated). */
 struct SnaccOpVersionInfo
 {
-	long long m_llAddedUnix = 0;
-	long long m_llDeprecatedUnix = 0;
+	unsigned long long m_ullAddedUnix = 0;
+	unsigned long long m_ullDeprecatedUnix = 0;
 };
 
 /*! Loaded module snapshot for negotiate / introspection on one ROSE stub instance. */
@@ -133,22 +133,6 @@ struct SnaccLoadedModuleInfo
 };
 
 using SnaccLoadedModuleMap = std::unordered_map<std::string, SnaccLoadedModuleInfo>;
-
-class SnaccROSESender;
-
-/*! Registers one ROSE operation on a stub sender (generated code entry point). */
-void SnaccRoseRegisterOperationOnSender(
-	SnaccROSESender* pSender,
-	unsigned int uiOpID,
-	const char* szOpName,
-	unsigned int uiInterfaceID,
-	const char* szModuleName,
-	long long llAddedUnix,
-	long long llDeprecatedUnix,
-	bool bIsEvent);
-
-/*! Registers module version metadata on a stub sender (generated code entry point). */
-void SnaccRoseRegisterModuleVersionOnSender(SnaccROSESender* pSender, const char* szModuleName, const char* szVersion);
 
 #define SNACC_TE_BER SNACC::TransportEncoding::BER
 #define SNACC_TE_JSON SNACC::TransportEncoding::JSON
@@ -248,9 +232,9 @@ public:
 		const char* szOpName,
 		unsigned int uiInterfaceID,
 		const char* szModuleName,
-		long long llAddedUnix,
-		long long llDeprecatedUnix,
-		bool bIsEvent);
+		bool bIsEvent = false,
+		unsigned long long ullAddedUnix = 0,
+		unsigned long long ullDeprecatedUnix = 0);
 
 	/*! Removes one operation from this stub registry. */
 	void UnregisterOperation(unsigned int uiOpID);

--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -141,9 +141,9 @@ class SnaccInvokeContextInit
 {
 public:
 	/*! @param szOperationName Optional. Inbound: synthetic name or resolved via lookup from
-		@p pInvoke. Outbound: stored when provided (deprecated stub default context);
+		@p pInvoke on @p pStubForLookup when set. Outbound: stored when provided (deprecated stub default context);
 		omit for normal outbound contexts (use CreateOutboundInvokeContext()). */
-	SnaccInvokeContextInit(SnaccInvokeDirection direction, SNACC::ROSEInvoke* pInvoke = nullptr, const char* szOperationName = nullptr);
+	SnaccInvokeContextInit(SnaccInvokeDirection direction, SNACC::ROSEInvoke* pInvoke = nullptr, const char* szOperationName = nullptr, const SnaccROSEBase* pStubForLookup = nullptr);
 
 	const SnaccInvokeDirection m_direction{};
 	const SNACC::ROSEInvoke* m_pInvoke{};
@@ -208,7 +208,7 @@ public:
 	/*! Returns the typed error buffer supplied to SetAsyncCompletion(). */
 	SNACC::AsnType* AsyncErrorBuffer() const;
 
-	/*! Inbound: canonical name from SnaccRoseOperationLookup. Outbound: set only when
+	/*! Inbound: canonical name from this stub registry. Outbound: set only when
 		passed explicitly to SnaccInvokeContextInit (e.g. deprecated stub). Send/telemetry
 		still use the stub literal at SendInvoke/SendEvent. */
 	const std::string& OperationName() const;

--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -385,6 +385,19 @@ public:
 	}
 
 protected:
+	/*! Registers module version metadata on the ROSE stub referenced by @c m_pSB. */
+	void RegisterModuleVersion(const char* szModuleName, const char* szVersion);
+
+	/*! Registers one ROSE operation on the ROSE stub referenced by @c m_pSB. */
+	void RegisterOperation(
+		unsigned int uiOpID,
+		const char* szOpName,
+		unsigned int uiInterfaceID,
+		const char* szModuleName,
+		bool bIsEvent = false,
+		unsigned long long ullAddedUnix = 0,
+		unsigned long long ullDeprecatedUnix = 0);
+
 	SnaccROSESender* m_pSB;
 };
 

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -606,24 +606,23 @@ SnaccROSEBase* AsRoseBase(SnaccROSESender* pSender)
 }
 } // namespace
 
-void SnaccRoseRegisterOperationOnSender(
-	SnaccROSESender* pSender,
+void SnaccROSEComponent::RegisterModuleVersion(const char* szModuleName, const char* szVersion)
+{
+	if (SnaccROSEBase* pStub = AsRoseBase(m_pSB))
+		pStub->RegisterModuleVersion(szModuleName, szVersion);
+}
+
+void SnaccROSEComponent::RegisterOperation(
 	unsigned int uiOpID,
 	const char* szOpName,
 	unsigned int uiInterfaceID,
 	const char* szModuleName,
-	long long llAddedUnix,
-	long long llDeprecatedUnix,
-	bool bIsEvent)
+	bool bIsEvent,
+	unsigned long long ullAddedUnix,
+	unsigned long long ullDeprecatedUnix)
 {
-	if (SnaccROSEBase* pStub = AsRoseBase(pSender))
-		pStub->RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, llAddedUnix, llDeprecatedUnix, bIsEvent);
-}
-
-void SnaccRoseRegisterModuleVersionOnSender(SnaccROSESender* pSender, const char* szModuleName, const char* szVersion)
-{
-	if (SnaccROSEBase* pStub = AsRoseBase(pSender))
-		pStub->RegisterModuleVersion(szModuleName, szVersion);
+	if (SnaccROSEBase* pStub = AsRoseBase(m_pSB))
+		pStub->RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, bIsEvent, ullAddedUnix, ullDeprecatedUnix);
 }
 
 void SnaccROSEBase::RegisterModuleVersion(const char* szModuleName, const char* szVersion)
@@ -641,9 +640,9 @@ void SnaccROSEBase::RegisterOperation(
 	const char* szOpName,
 	unsigned int uiInterfaceID,
 	const char* szModuleName,
-	long long llAddedUnix,
-	long long llDeprecatedUnix,
-	bool bIsEvent)
+	bool bIsEvent,
+	unsigned long long ullAddedUnix,
+	unsigned long long ullDeprecatedUnix)
 {
 	if (!szOpName || !szModuleName)
 		return;
@@ -667,8 +666,8 @@ void SnaccROSEBase::RegisterOperation(
 	module.m_strModuleName = szModuleName;
 
 	SnaccOpVersionInfo info;
-	info.m_llAddedUnix = llAddedUnix;
-	info.m_llDeprecatedUnix = llDeprecatedUnix;
+	info.m_ullAddedUnix = ullAddedUnix;
+	info.m_ullDeprecatedUnix = ullDeprecatedUnix;
 	if (bIsEvent)
 		module.m_events[uiOpID] = info;
 	else

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -1,6 +1,7 @@
 #include "../include/SnaccROSEBase.h"
 #include "../include/SNACCROSE.h"
 #include "snacc-assert.h"
+#include <vector>
 #include <stdio.h>
 #include <wchar.h>
 #include <iomanip>
@@ -28,23 +29,29 @@ namespace
 {
 	/*! Outbound operation name for telemetry, logging, and JSON encode.
 	 * The generated stub literal is authoritative; lookup by operationID is only a fallback. */
-	const char* ResolveOperationNameFromStub(const char* szStubOperationName, unsigned int uiOperationID)
+	const char* ResolveOperationNameFromStub(const char* szStubOperationName, unsigned int uiOperationID, const SnaccROSEBase* pStub)
 	{
 		if (szStubOperationName && szStubOperationName[0] != '\0')
 			return szStubOperationName;
 
-		const char* szLookupName = SnaccRoseOperationLookup::LookUpName(uiOperationID);
+		if (!pStub)
+			return "";
+
+		const char* szLookupName = pStub->LookUpName(uiOperationID);
 		return szLookupName ? szLookupName : "";
 	}
 
 	/*! Inbound SnaccInvokeContext operation name from operationID only.
 	 * Wire operationName is not used; szExplicitName is for synthetic inbound paths without a decoded invoke. */
-	std::string ResolveInboundContextOperationName(const SNACC::ROSEInvoke& invoke, const char* szExplicitName)
+	std::string ResolveInboundContextOperationName(const SNACC::ROSEInvoke& invoke, const char* szExplicitName, const SnaccROSEBase* pStub)
 	{
 		if (szExplicitName && szExplicitName[0] != '\0')
 			return szExplicitName;
 
-		const char* szLookupName = SnaccRoseOperationLookup::LookUpName(invoke.operationID);
+		if (!pStub)
+			return "";
+
+		const char* szLookupName = pStub->LookUpName(invoke.operationID);
 		if (szLookupName)
 			return szLookupName;
 
@@ -53,12 +60,12 @@ namespace
 
 	/*! When the client sends operationID 0 with operationName (JSON pattern), resolve the
 	 * real ID from the lookup map so stub dispatch and context naming use operationID. */
-	void PrepareInboundInvokeOperationId(SNACC::ROSEInvoke& invoke)
+	void PrepareInboundInvokeOperationId(SNACC::ROSEInvoke& invoke, const SnaccROSEBase& stub)
 	{
 		if (invoke.operationID || !invoke.operationName)
 			return;
 
-		const unsigned int uiResolvedOperationId = SnaccRoseOperationLookup::LookUpID(invoke.operationName->getASCII().c_str());
+		const unsigned int uiResolvedOperationId = stub.LookUpID(invoke.operationName->getASCII().c_str());
 		if (uiResolvedOperationId)
 			invoke.operationID = uiResolvedOperationId;
 	}
@@ -66,13 +73,13 @@ namespace
 	/*! Fills SnaccInvokeContextInit::m_strOperationName. Outbound: uses @p szOperationName
 	 * when provided (e.g. deprecated stub default context); otherwise empty. Inbound: lookup
 	 * from operationID or explicit synthetic name. */
-	std::string MakeInvokeContextOperationName(SnaccInvokeDirection direction, const SNACC::ROSEInvoke* pInvoke, const char* szOperationName)
+	std::string MakeInvokeContextOperationName(SnaccInvokeDirection direction, const SNACC::ROSEInvoke* pInvoke, const char* szOperationName, const SnaccROSEBase* pStub)
 	{
 		if (direction == SnaccInvokeDirection::OUTBOUND)
 			return (szOperationName && szOperationName[0] != '\0') ? szOperationName : std::string{};
 
 		if (pInvoke)
-			return ResolveInboundContextOperationName(*pInvoke, szOperationName);
+			return ResolveInboundContextOperationName(*pInvoke, szOperationName, pStub);
 
 		return szOperationName ? szOperationName : "";
 	}
@@ -254,10 +261,10 @@ namespace
 	};
 } // namespace
 
-SnaccInvokeContextInit::SnaccInvokeContextInit(SnaccInvokeDirection direction, SNACC::ROSEInvoke* pInvoke /*= nullptr*/, const char* szOperationName /*= nullptr*/)
+SnaccInvokeContextInit::SnaccInvokeContextInit(SnaccInvokeDirection direction, SNACC::ROSEInvoke* pInvoke /*= nullptr*/, const char* szOperationName /*= nullptr*/, const SnaccROSEBase* pStubForLookup /*= nullptr*/)
 	: m_direction(direction),
 	  m_pInvoke(pInvoke),
-	  m_strOperationName(MakeInvokeContextOperationName(direction, pInvoke, szOperationName))
+	  m_strOperationName(MakeInvokeContextOperationName(direction, pInvoke, szOperationName, pStubForLookup))
 {
 }
 
@@ -391,7 +398,7 @@ std::string getPrettyPrinted(const SJson::Value& value)
 	return SJson::writeString(wbuilder, value);
 }
 
-std::optional<SnaccROSEBase::InboundInvokeRejectContext> SnaccROSEBase::InboundInvokeRejectContext::TryFrom(const SNACC::ROSEMessage& message)
+std::optional<SnaccROSEBase::InboundInvokeRejectContext> SnaccROSEBase::InboundInvokeRejectContext::TryFrom(const SNACC::ROSEMessage& message, const SnaccROSEBase& stub)
 {
 	if (message.choiceId != ROSEMessage::invokeCid || !message.invoke)
 		return std::nullopt;
@@ -399,9 +406,9 @@ std::optional<SnaccROSEBase::InboundInvokeRejectContext> SnaccROSEBase::InboundI
 	InboundInvokeRejectContext ctx;
 	ctx.m_invokeId = pInvoke->invokeID;
 	SNACC::ROSEInvoke invokeCopy = *pInvoke;
-	PrepareInboundInvokeOperationId(invokeCopy);
+	PrepareInboundInvokeOperationId(invokeCopy, stub);
 	ctx.m_uiOperationID = invokeCopy.operationID;
-	ctx.m_strOperationName = ResolveInboundContextOperationName(invokeCopy, nullptr);
+	ctx.m_strOperationName = ResolveInboundContextOperationName(invokeCopy, nullptr, &stub);
 	return ctx;
 }
 
@@ -591,24 +598,62 @@ SnaccTelemetryData::Stage GetOutboundUnhandledStageFromResult(const long lRoseRe
 }
 
 // check if at least one Operation has been registerd
-bool SnaccRoseOperationLookup::Initialized()
+namespace
 {
-	return m_mapOpToID.empty() ? false : true;
+SnaccROSEBase* AsRoseBase(SnaccROSESender* pSender)
+{
+	return dynamic_cast<SnaccROSEBase*>(pSender);
+}
+} // namespace
+
+void SnaccRoseRegisterOperationOnSender(
+	SnaccROSESender* pSender,
+	unsigned int uiOpID,
+	const char* szOpName,
+	unsigned int uiInterfaceID,
+	const char* szModuleName,
+	long long llAddedUnix,
+	long long llDeprecatedUnix,
+	bool bIsEvent)
+{
+	if (SnaccROSEBase* pStub = AsRoseBase(pSender))
+		pStub->RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, llAddedUnix, llDeprecatedUnix, bIsEvent);
 }
 
-void SnaccRoseOperationLookup::CleanUp()
+void SnaccRoseRegisterModuleVersionOnSender(SnaccROSESender* pSender, const char* szModuleName, const char* szVersion)
 {
-	m_mapOpToID.clear();
-	m_mapIDToOp.clear();
-	m_mapIDToInterface.clear();
+	if (SnaccROSEBase* pStub = AsRoseBase(pSender))
+		pStub->RegisterModuleVersion(szModuleName, szVersion);
 }
 
-void SnaccRoseOperationLookup::RegisterOperation(unsigned int uiOpID, const char* szOpName, unsigned int uiInterfaceID)
+void SnaccROSEBase::RegisterModuleVersion(const char* szModuleName, const char* szVersion)
 {
-#ifdef _DEBUG
+	if (!szModuleName || !szVersion)
+		return;
+
+	auto& module = m_loadedModules[szModuleName];
+	module.m_strModuleName = szModuleName;
+	module.m_strVersion = szVersion;
+}
+
+void SnaccROSEBase::RegisterOperation(
+	unsigned int uiOpID,
+	const char* szOpName,
+	unsigned int uiInterfaceID,
+	const char* szModuleName,
+	long long llAddedUnix,
+	long long llDeprecatedUnix,
+	bool bIsEvent)
+{
+	if (!szOpName || !szModuleName)
+		return;
+
 	if (m_mapIDToOp.find(uiOpID) != m_mapIDToOp.end())
+		return;
+
+#ifdef _DEBUG
+	if (m_mapOpToID.find(szOpName) != m_mapOpToID.end())
 	{
-		// In case we land here we have two operations using the same operationID
 		ASSERT(0);
 	}
 #endif
@@ -616,27 +661,91 @@ void SnaccRoseOperationLookup::RegisterOperation(unsigned int uiOpID, const char
 	m_mapOpToID[szOpName] = uiOpID;
 	m_mapIDToOp[uiOpID] = szOpName;
 	m_mapIDToInterface[uiOpID] = uiInterfaceID;
+	m_mapIDToModuleKind[uiOpID] = {szModuleName, bIsEvent};
+
+	auto& module = m_loadedModules[szModuleName];
+	module.m_strModuleName = szModuleName;
+
+	SnaccOpVersionInfo info;
+	info.m_llAddedUnix = llAddedUnix;
+	info.m_llDeprecatedUnix = llDeprecatedUnix;
+	if (bIsEvent)
+		module.m_events[uiOpID] = info;
+	else
+		module.m_invokes[uiOpID] = info;
 }
 
-unsigned int SnaccRoseOperationLookup::LookUpInterfaceID(unsigned int uiOpID)
+void SnaccROSEBase::UnregisterOperation(unsigned int uiOpID)
 {
-	const auto it = m_mapIDToInterface.find(uiOpID);
-	if (it != m_mapIDToInterface.end())
-		return it->second;
+	const auto moduleKindIt = m_mapIDToModuleKind.find(uiOpID);
+	if (moduleKindIt != m_mapIDToModuleKind.end())
+	{
+		auto moduleIt = m_loadedModules.find(moduleKindIt->second.first);
+		if (moduleIt != m_loadedModules.end())
+		{
+			if (moduleKindIt->second.second)
+				moduleIt->second.m_events.erase(uiOpID);
+			else
+				moduleIt->second.m_invokes.erase(uiOpID);
+		}
+		m_mapIDToModuleKind.erase(moduleKindIt);
+	}
 
-	return 0;
+	const auto idIt = m_mapIDToOp.find(uiOpID);
+	if (idIt != m_mapIDToOp.end())
+	{
+		m_mapOpToID.erase(idIt->second);
+		m_mapIDToOp.erase(idIt);
+	}
+
+	m_mapIDToInterface.erase(uiOpID);
 }
 
-const char* SnaccRoseOperationLookup::LookUpName(unsigned int uiOpID)
+void SnaccROSEBase::UnregisterModule(const char* szModuleName)
+{
+	if (!szModuleName)
+		return;
+
+	std::vector<unsigned int> opIds;
+	for (const auto& entry : m_mapIDToModuleKind)
+	{
+		if (entry.second.first == szModuleName)
+			opIds.push_back(entry.first);
+	}
+
+	for (const unsigned int uiOpID : opIds)
+		UnregisterOperation(uiOpID);
+
+	m_loadedModules.erase(szModuleName);
+}
+
+void SnaccROSEBase::ClearRegisteredOperations()
+{
+	m_mapOpToID.clear();
+	m_mapIDToOp.clear();
+	m_mapIDToInterface.clear();
+	m_mapIDToModuleKind.clear();
+	m_loadedModules.clear();
+}
+
+bool SnaccROSEBase::HasRegisteredOperations() const
+{
+	return !m_mapIDToOp.empty();
+}
+
+const SnaccLoadedModuleMap& SnaccROSEBase::GetLoadedModules() const
+{
+	return m_loadedModules;
+}
+
+const char* SnaccROSEBase::LookUpName(unsigned int uiOpID) const
 {
 	const auto it = m_mapIDToOp.find(uiOpID);
 	if (it != m_mapIDToOp.end())
 		return it->second.c_str();
 
 #ifdef _DEBUG
-	// This may only happen if the other side calls a method we are not aware of
-	// We handle it here as assert as it should not happen in development
-	static std::mutex s_mutex; // prevents multiple threads to write to the log at the same time
+	static std::mutex s_mutex;
 	static std::set<int> s_unknownOpIDsAlreadyNotified;
 	std::lock_guard<std::mutex> lock(s_mutex);
 	if (!s_unknownOpIDsAlreadyNotified.contains(uiOpID))
@@ -649,10 +758,22 @@ const char* SnaccRoseOperationLookup::LookUpName(unsigned int uiOpID)
 	return nullptr;
 }
 
-unsigned int SnaccRoseOperationLookup::LookUpID(const char* szOpName)
+unsigned int SnaccROSEBase::LookUpID(const char* szOpName) const
 {
+	if (!szOpName)
+		return 0;
+
 	const auto it = m_mapOpToID.find(szOpName);
 	if (it != m_mapOpToID.end())
+		return it->second;
+
+	return 0;
+}
+
+unsigned int SnaccROSEBase::LookUpInterfaceID(unsigned int uiOpID) const
+{
+	const auto it = m_mapIDToInterface.find(uiOpID);
+	if (it != m_mapIDToInterface.end())
 		return it->second;
 
 	return 0;
@@ -948,7 +1069,7 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 					try
 					{
 						pMessage->BDec(buffer, bytesDecoded);
-						rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage);
+						rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage, *this);
 						if (bLogTransportData)
 							LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, lSize, nullptr, nullptr);
 
@@ -976,7 +1097,7 @@ bool SnaccROSEBase::OnBinaryDataBlockResult(const char* lpBytes, unsigned long l
 							if (!pMessage->JDec(value))
 								throw InvalidTagException("ROSEMessage", "decode failed: ROSEMessage", STACK_ENTRY);
 
-							rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage);
+							rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage, *this);
 							if (bLogTransportData)
 								LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, lSize, pMessage.get(), &value);
 
@@ -1110,7 +1231,7 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long ulSize,
 					try
 					{
 						pMessage->BDec(buffer, bytesDecoded);
-						rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage);
+						rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage, *this);
 						if (bLogTransportData)
 							LogTransportData(false, SNACC::TransportEncoding::BER, nullptr, lpBytes, ulSize, nullptr, nullptr);
 
@@ -1137,7 +1258,7 @@ void SnaccROSEBase::OnBinaryDataBlock(const char* lpBytes, unsigned long ulSize,
 						{
 							if (!pMessage->JDec(value))
 								throw InvalidTagException("ROSEMessage", "decode failed: ROSEMessage", STACK_ENTRY);
-							rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage);
+							rejectCtx = InboundInvokeRejectContext::TryFrom(*pMessage, *this);
 							if (bLogTransportData)
 								LogTransportData(false, m_eTransportEncoding, nullptr, lpBytes, ulSize, pMessage.get(), &value);
 							OnROSEMessage(std::move(pMessage), true, ulSize);
@@ -1183,7 +1304,7 @@ bool SnaccROSEBase::OnROSEMessage(std::unique_ptr<SNACC::ROSEMessage> pMessage, 
 		case ROSEMessage::invokeCid:
 			{
 				auto& invoke = *pMessage->invoke;
-				PrepareInboundInvokeOperationId(invoke);
+				PrepareInboundInvokeOperationId(invoke, *this);
 				if (bAllowAllInvokes || m_multithreadInvokeIDs.find(invoke.operationID) != m_multithreadInvokeIDs.end())
 				{
 					if (invoke.operationID || invoke.operationName)
@@ -1378,8 +1499,8 @@ void SnaccROSEBase::OnInvokeMessage(std::unique_ptr<SNACC::ROSEMessage> pMessage
 	std::string strResponse;
 	long lResult = ROSE_REJECT_UNKNOWNOPERATION;
 	auto& invoke = *pMessage->invoke;
-	PrepareInboundInvokeOperationId(invoke);
-	SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, &invoke);
+	PrepareInboundInvokeOperationId(invoke, *this);
+	SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, &invoke, nullptr, this);
 	auto pCtx = CreateInvokeContext(init);
 	const char* szOperationName = pCtx->OperationNameCStr();
 	auto telemetry = SnaccTelemetryData::Create(SnaccTelemetryData::Direction::INBOUND, invoke.operationID, szOperationName, ulMessageSize);
@@ -1569,7 +1690,7 @@ long SnaccROSEBase::Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName
 long SnaccROSEBase::SendEvent(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)
 {
 	const auto chronoCreated = std::chrono::steady_clock::now();
-	const char* szResolvedOperationName = ResolveOperationNameFromStub(szOperationName, pInvoke->operationID);
+	const char* szResolvedOperationName = ResolveOperationNameFromStub(szOperationName, pInvoke->operationID, this);
 	if (!pCtx)
 		pCtx = CreateInvokeContext(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND, pInvoke));
 	auto& ctx = *pCtx;
@@ -1605,7 +1726,7 @@ bool SnaccROSEBase::LogTransportData(const bool bOutbound, const SNACC::Transpor
 						szOperationName = strOperationName.c_str();
 				}
 				if (!szOperationName)
-					szOperationName = ResolveOperationNameFromStub(nullptr, pMsg->invoke->operationID);
+					szOperationName = ResolveOperationNameFromStub(nullptr, pMsg->invoke->operationID, this);
 			}
 
 			// JSON logging is requested
@@ -1670,7 +1791,7 @@ bool SnaccROSEBase::LogTransportData(const bool bOutbound, const SNACC::Transpor
 long SnaccROSEBase::SendInvoke(SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, SNACC::AsnType* pError, const char* szOperationName /*= nullptr*/, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)
 {
 	const auto chronoCreated = std::chrono::steady_clock::now();
-	const char* szResolvedOperationName = ResolveOperationNameFromStub(szOperationName, pInvoke->operationID);
+	const char* szResolvedOperationName = ResolveOperationNameFromStub(szOperationName, pInvoke->operationID, this);
 
 	// Ensure that we always have a ctx
 	if (!pCtx)
@@ -1912,7 +2033,7 @@ void SnaccROSEBase::StopWatchdogThread()
 long SnaccROSEBase::SendInvokeAsync(SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, SNACC::AsnType* pError, const char* szOperationName /*= nullptr*/, std::shared_ptr<SnaccInvokeContext> pCtx /*= {}*/)
 {
 	const auto chronoCreated = std::chrono::steady_clock::now();
-	const char* szResolvedOperationName = ResolveOperationNameFromStub(szOperationName, pInvoke->operationID);
+	const char* szResolvedOperationName = ResolveOperationNameFromStub(szOperationName, pInvoke->operationID, this);
 
 	if (!pCtx)
 		pCtx = CreateInvokeContext(SnaccInvokeContextInit(SnaccInvokeDirection::OUTBOUND, pInvoke));
@@ -2334,7 +2455,7 @@ long SnaccROSEBase::DecodeInvoke(const SNACC::ROSEMessage& invokeMessage, SNACC:
 					szOperationName = strOperationName.c_str();
 				}
 				if (!szOperationName)
-					szOperationName = ResolveOperationNameFromStub(nullptr, logInvoke.operationID);
+					szOperationName = ResolveOperationNameFromStub(nullptr, logInvoke.operationID, this);
 				LogTransportData(false, SNACC::TransportEncoding::BER, szOperationName, nullptr, 0, &logMsg, nullptr);
 				// As we hand back the result object to the outer world (function argument) we need to set it to NULL to prevent deletion if we discard the inserted object
 				logInvoke.argument->value = NULL;

--- a/cpp-lib/tests/CMakeLists.txt
+++ b/cpp-lib/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(cpp-lib-sample-runtime-tests
 	invoke_context_tests.cpp
 	logging_tests.cpp
 	logical_failure_tests.cpp
+	module_registry_tests.cpp
 	public_api_tests.cpp
 	telemetry_tests.cpp
 	transport_failure_tests.cpp

--- a/cpp-lib/tests/invoke_context_tests.cpp
+++ b/cpp-lib/tests/invoke_context_tests.cpp
@@ -749,7 +749,7 @@ namespace sample_runtime_tests
 	TEST(InvokeContextInitTest, InboundInitResolvesOperationNameFromInvokeLookup)
 	{
 		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session"};
-		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", 0, 0, false);
+		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", false);
 
 		ROSEInvoke invoke;
 		invoke.invokeID = 1;
@@ -769,7 +769,7 @@ namespace sample_runtime_tests
 	TEST(InvokeContextInitTest, InboundResolvesOperationIdFromNameThenCanonicalContextName)
 	{
 		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session"};
-		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", 0, 0, false);
+		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", false);
 
 		ROSEInvoke invoke;
 		invoke.invokeID = 1;

--- a/cpp-lib/tests/invoke_context_tests.cpp
+++ b/cpp-lib/tests/invoke_context_tests.cpp
@@ -748,28 +748,28 @@ namespace sample_runtime_tests
 
 	TEST(InvokeContextInitTest, InboundInitResolvesOperationNameFromInvokeLookup)
 	{
-		SnaccRoseOperationLookup::CleanUp();
-		SnaccRoseOperationLookup::RegisterOperation(43210, "asnTestInboundName", 1);
+		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session"};
+		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", 0, 0, false);
 
 		ROSEInvoke invoke;
 		invoke.invokeID = 1;
 		invoke.operationID = 43210;
 		invoke.operationName = UTF8String::CreateNewFromASCII("wrongWireName");
 
-		const SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, &invoke);
+		const SnaccInvokeContextInit init(SnaccInvokeDirection::INBOUND, &invoke, nullptr, &endpoint);
 		EXPECT_EQ("asnTestInboundName", init.m_strOperationName);
 
 		const auto pCtx = SnaccInvokeContext::Create(init);
 		ASSERT_NE(nullptr, pCtx);
 		EXPECT_EQ("asnTestInboundName", pCtx->OperationName());
 
-		SnaccRoseOperationLookup::CleanUp();
+		endpoint.ClearRegisteredOperations();
 	}
 
 	TEST(InvokeContextInitTest, InboundResolvesOperationIdFromNameThenCanonicalContextName)
 	{
-		SnaccRoseOperationLookup::CleanUp();
-		SnaccRoseOperationLookup::RegisterOperation(43210, "asnTestInboundName", 1);
+		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session"};
+		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", 0, 0, false);
 
 		ROSEInvoke invoke;
 		invoke.invokeID = 1;
@@ -777,14 +777,14 @@ namespace sample_runtime_tests
 		invoke.operationName = UTF8String::CreateNewFromASCII("asnTestInboundName");
 
 		if (invoke.operationName && invoke.operationID == 0)
-			invoke.operationID = SnaccRoseOperationLookup::LookUpID(invoke.operationName->getASCII().c_str());
+			invoke.operationID = endpoint.LookUpID(invoke.operationName->getASCII().c_str());
 		ASSERT_EQ(43210u, static_cast<unsigned int>(invoke.operationID));
 
-		const auto pCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, &invoke));
+		const auto pCtx = SnaccInvokeContext::Create(SnaccInvokeContextInit(SnaccInvokeDirection::INBOUND, &invoke, nullptr, &endpoint));
 		ASSERT_NE(nullptr, pCtx);
 		EXPECT_EQ("asnTestInboundName", pCtx->OperationName());
 
-		SnaccRoseOperationLookup::CleanUp();
+		endpoint.ClearRegisteredOperations();
 	}
 
 } // namespace sample_runtime_tests

--- a/cpp-lib/tests/module_registry_tests.cpp
+++ b/cpp-lib/tests/module_registry_tests.cpp
@@ -1,0 +1,102 @@
+#include "test_support/sample_runtime_harness.h"
+
+#include <gtest/gtest.h>
+
+namespace sample_runtime_tests
+{
+namespace
+{
+const char* kSettingsModuleName = "ENetUC_Settings_Manager";
+
+void ExpectOpInfo(const SnaccOpVersionInfo& info, const bool bExpectAdded, const bool bExpectDeprecated)
+{
+	if (bExpectAdded)
+		EXPECT_GT(info.m_llAddedUnix, 0);
+	else
+		EXPECT_EQ(0, info.m_llAddedUnix);
+
+	if (bExpectDeprecated)
+		EXPECT_GT(info.m_llDeprecatedUnix, 0);
+	else
+		EXPECT_EQ(0, info.m_llDeprecatedUnix);
+}
+} // namespace
+
+TEST(ModuleRegistryTest, GeneratedModuleRegistersOnlyOnMountedStub)
+{
+	RuntimeEndpoint endpointA{L"RegistryEndpointA", "registry-a"};
+	RuntimeEndpoint endpointB{L"RegistryEndpointB", "registry-b"};
+
+	ENetUC_Settings_ManagerROSE settingsOnA(&endpointA);
+
+	EXPECT_TRUE(endpointA.HasRegisteredOperations());
+	EXPECT_FALSE(endpointB.HasRegisteredOperations());
+
+	const auto& modulesA = endpointA.GetLoadedModules();
+	ASSERT_EQ(1u, modulesA.size());
+	const auto moduleIt = modulesA.find(kSettingsModuleName);
+	ASSERT_NE(modulesA.end(), moduleIt);
+	EXPECT_FALSE(moduleIt->second.m_strVersion.empty());
+	EXPECT_GE(moduleIt->second.m_invokes.size(), 3u);
+	EXPECT_EQ(1u, moduleIt->second.m_events.size());
+	EXPECT_NE(moduleIt->second.m_events.end(), moduleIt->second.m_events.find(4150u));
+
+	endpointA.ClearRegisteredOperations();
+	EXPECT_FALSE(endpointA.HasRegisteredOperations());
+	EXPECT_TRUE(endpointA.GetLoadedModules().empty());
+}
+
+TEST(ModuleRegistryTest, RegisteredMetadataMatchesLoadedModuleSnapshot)
+{
+	RuntimeEndpoint endpoint{L"RegistryMetadata", "registry-metadata"};
+	ENetUC_Settings_ManagerROSE settings(&endpoint);
+
+	const auto& modules = endpoint.GetLoadedModules();
+	ASSERT_EQ(1u, modules.size());
+	const auto& module = modules.begin()->second;
+
+	EXPECT_EQ(kSettingsModuleName, module.m_strModuleName);
+	EXPECT_FALSE(module.m_strVersion.empty());
+
+	ASSERT_NE(module.m_invokes.end(), module.m_invokes.find(4100u));
+	ASSERT_NE(module.m_invokes.end(), module.m_invokes.find(4101u));
+	ASSERT_NE(module.m_invokes.end(), module.m_invokes.find(4102u));
+	ExpectOpInfo(module.m_invokes.at(4100u), true, false);
+	ExpectOpInfo(module.m_invokes.at(4101u), false, false);
+	ExpectOpInfo(module.m_invokes.at(4102u), false, true);
+
+	ASSERT_NE(module.m_events.end(), module.m_events.find(4150u));
+	ExpectOpInfo(module.m_events.at(4150u), false, false);
+
+	EXPECT_EQ(4100u, endpoint.LookUpID("asnGetSettings"));
+	EXPECT_STREQ("asnGetSettings", endpoint.LookUpName(4100u));
+	EXPECT_EQ(ENetUC_Settings_ManagerROSE::m_iid, endpoint.LookUpInterfaceID(4100u));
+}
+
+TEST(ModuleRegistryTest, RuntimeFixtureKeepsClientAndServerRegistriesSeparate)
+{
+	RuntimeEndpoint server{L"RegistryServer", "registry-server"};
+	RuntimeEndpoint client{L"RegistryClient", "registry-client"};
+	server.ConnectTo(client);
+	client.ConnectTo(server);
+
+	SettingsServiceModule serverSettings(server);
+	SettingsClientModule clientSettings(client);
+
+	EXPECT_TRUE(server.HasRegisteredOperations());
+	EXPECT_TRUE(client.HasRegisteredOperations());
+
+	const auto& serverModules = server.GetLoadedModules();
+	const auto& clientModules = client.GetLoadedModules();
+
+	EXPECT_FALSE(serverModules.empty());
+	EXPECT_FALSE(clientModules.empty());
+	EXPECT_NE(serverModules.find(kSettingsModuleName), serverModules.end());
+	EXPECT_NE(clientModules.find(kSettingsModuleName), clientModules.end());
+
+	server.ClearRegisteredOperations();
+	EXPECT_TRUE(server.GetLoadedModules().empty());
+	EXPECT_FALSE(client.GetLoadedModules().empty());
+}
+
+} // namespace sample_runtime_tests

--- a/cpp-lib/tests/module_registry_tests.cpp
+++ b/cpp-lib/tests/module_registry_tests.cpp
@@ -11,14 +11,14 @@ const char* kSettingsModuleName = "ENetUC_Settings_Manager";
 void ExpectOpInfo(const SnaccOpVersionInfo& info, const bool bExpectAdded, const bool bExpectDeprecated)
 {
 	if (bExpectAdded)
-		EXPECT_GT(info.m_llAddedUnix, 0);
+		EXPECT_GT(info.m_ullAddedUnix, 0u);
 	else
-		EXPECT_EQ(0, info.m_llAddedUnix);
+		EXPECT_EQ(0u, info.m_ullAddedUnix);
 
 	if (bExpectDeprecated)
-		EXPECT_GT(info.m_llDeprecatedUnix, 0);
+		EXPECT_GT(info.m_ullDeprecatedUnix, 0u);
 	else
-		EXPECT_EQ(0, info.m_llDeprecatedUnix);
+		EXPECT_EQ(0u, info.m_ullDeprecatedUnix);
 }
 } // namespace
 

--- a/cpp-lib/tests/public_api_tests.cpp
+++ b/cpp-lib/tests/public_api_tests.cpp
@@ -294,7 +294,7 @@ TEST(PublicApiSmokeTest, OperationLookupRegistersAndCleansUp)
 	ObservedRuntimeEndpoint endpoint{L"LookupEndpoint", "lookup-session"};
 	EXPECT_FALSE(endpoint.HasRegisteredOperations());
 
-	endpoint.RegisterOperation(3210, "testOperation", 77, "TestModule", 0, 0, false);
+	endpoint.RegisterOperation(3210, "testOperation", 77, "TestModule", false);
 	EXPECT_TRUE(endpoint.HasRegisteredOperations());
 	EXPECT_EQ(3210u, endpoint.LookUpID("testOperation"));
 	ASSERT_NE(nullptr, endpoint.LookUpName(3210));

--- a/cpp-lib/tests/public_api_tests.cpp
+++ b/cpp-lib/tests/public_api_tests.cpp
@@ -261,8 +261,6 @@ TEST(PublicApiSmokeTest, ConfigureFileLoggingWritesAndCanBeDisabled)
 {
 	ObservedRuntimeEndpoint endpoint{L"FileLoggingEndpoint", "file-session"};
 	TransportProbe transport;
-	SnaccRoseOperationLookup::CleanUp();
-	ENetUC_Settings_ManagerROSE::RegisterOperations();
 	endpoint.SetTransportEncoding(TransportEncoding::JSON_NO_HEADING);
 	endpoint.SetSnaccROSETransport(&transport);
 	endpoint.SetLogLevels(EAsnLogLevel::JSON, EAsnLogLevel::JSON);
@@ -289,26 +287,25 @@ TEST(PublicApiSmokeTest, ConfigureFileLoggingWritesAndCanBeDisabled)
 	EXPECT_NE(std::string::npos, fileContents.find("file-log-user"));
 
 	std::filesystem::remove(logPath);
-	SnaccRoseOperationLookup::CleanUp();
 }
 
 TEST(PublicApiSmokeTest, OperationLookupRegistersAndCleansUp)
 {
-	SnaccRoseOperationLookup::CleanUp();
-	EXPECT_FALSE(SnaccRoseOperationLookup::Initialized());
+	ObservedRuntimeEndpoint endpoint{L"LookupEndpoint", "lookup-session"};
+	EXPECT_FALSE(endpoint.HasRegisteredOperations());
 
-	SnaccRoseOperationLookup::RegisterOperation(3210, "testOperation", 77);
-	EXPECT_TRUE(SnaccRoseOperationLookup::Initialized());
-	EXPECT_EQ(3210u, SnaccRoseOperationLookup::LookUpID("testOperation"));
-	ASSERT_NE(nullptr, SnaccRoseOperationLookup::LookUpName(3210));
-	EXPECT_STREQ("testOperation", SnaccRoseOperationLookup::LookUpName(3210));
-	EXPECT_EQ(77u, SnaccRoseOperationLookup::LookUpInterfaceID(3210));
+	endpoint.RegisterOperation(3210, "testOperation", 77, "TestModule", 0, 0, false);
+	EXPECT_TRUE(endpoint.HasRegisteredOperations());
+	EXPECT_EQ(3210u, endpoint.LookUpID("testOperation"));
+	ASSERT_NE(nullptr, endpoint.LookUpName(3210));
+	EXPECT_STREQ("testOperation", endpoint.LookUpName(3210));
+	EXPECT_EQ(77u, endpoint.LookUpInterfaceID(3210));
 
-	SnaccRoseOperationLookup::CleanUp();
-	EXPECT_FALSE(SnaccRoseOperationLookup::Initialized());
-	EXPECT_EQ(0u, SnaccRoseOperationLookup::LookUpID("testOperation"));
-	EXPECT_EQ(nullptr, SnaccRoseOperationLookup::LookUpName(3210));
-	EXPECT_EQ(0u, SnaccRoseOperationLookup::LookUpInterfaceID(3210));
+	endpoint.ClearRegisteredOperations();
+	EXPECT_FALSE(endpoint.HasRegisteredOperations());
+	EXPECT_EQ(0u, endpoint.LookUpID("testOperation"));
+	EXPECT_EQ(nullptr, endpoint.LookUpName(3210));
+	EXPECT_EQ(0u, endpoint.LookUpInterfaceID(3210));
 }
 
 TEST(PublicApiSmokeTest, TelemetryDebugTextCoversGroupedRejectReasons)

--- a/cpp-lib/tests/test_support/sample_runtime_harness.h
+++ b/cpp-lib/tests/test_support/sample_runtime_harness.h
@@ -642,7 +642,7 @@ public:
 	// Generic interface-id based dispatcher used by all tests in this harness.
 	long OnInvoke(std::unique_ptr<ROSEMessage>& pMsg, SnaccInvokeContext& ctx, std::string& strResponse) override
 	{
-		const unsigned int interfaceId = SnaccRoseOperationLookup::LookUpInterfaceID(pMsg->invoke->operationID);
+		const unsigned int interfaceId = LookUpInterfaceID(pMsg->invoke->operationID);
 		const auto it = m_modules.find(interfaceId);
 		if (it == m_modules.end())
 			return ROSE_REJECT_UNKNOWNOPERATION;
@@ -1223,20 +1223,6 @@ inline void LoopbackTransport::FlushQueuedMessages()
 class RuntimeTestBase : public ::testing::Test
 {
 protected:
-	// Registers generated operation ids once for the whole fixture hierarchy.
-	static void SetUpTestSuite()
-	{
-		SnaccRoseOperationLookup::CleanUp();
-		ENetUC_Settings_ManagerROSE::RegisterOperations();
-		ENetUC_Event_ManagerROSE::RegisterOperations();
-	}
-
-	// Resets the global operation registry after the suite is finished.
-	static void TearDownTestSuite()
-	{
-		SnaccRoseOperationLookup::CleanUp();
-	}
-
 	// Constructs all modules around the already constructed client/server hosts.
 	RuntimeTestBase()
 		: m_telemetryRecorder(),

--- a/samples/prepare.js
+++ b/samples/prepare.js
@@ -94,7 +94,6 @@ function runCompiler(compiler, outputDir, compilerArgs, asn1Files) {
 		...compilerArgs,
 		`-node:${NODE_VERSION}`,
 		"-comments",
-		"-versionfile",
 		...asn1Files,
 	];
 	const result = spawnSync(compiler, args, {

--- a/samples/ts-microservice/node-client/src/run-tests.ts
+++ b/samples/ts-microservice/node-client/src/run-tests.ts
@@ -9,11 +9,14 @@ import {
 	assertInvokeResult,
 	createEventIntegration,
 	createSettingsIntegration,
+	EventCollector,
+	IntegrationClient,
 	releaseIntegration,
 	waitForCount,
 } from "./integration_client.js";
 import * as ENetUC_Event_Manager from "./stub/ENetUC_Event_Manager.js";
 import * as ENetUC_Settings_Manager from "./stub/ENetUC_Settings_Manager.js";
+import { ENetUC_Settings_ManagerROSE } from "./stub/ENetUC_Settings_ManagerROSE.js";
 import { EASN1TransportEncoding } from "./stub/TSInvokeContext.js";
 import {
 	assertNodeServerTestLayout,
@@ -25,6 +28,26 @@ const testDir = path.dirname(fileURLToPath(import.meta.url));
 const nodeClientRoot = path.resolve(testDir, "..");
 const { nodeServerRoot, testPort, logDirectory } = resolveIntegrationRunnerEnv(nodeClientRoot);
 assertNodeServerTestLayout(nodeServerRoot);
+
+describe("loaded module registry", () => {
+	test("getLoadedModules reflects setHandler registration", () => {
+		const client = new IntegrationClient(testPort, EASN1TransportEncoding.JSON);
+		const collector = new EventCollector();
+		const settingsRose = new ENetUC_Settings_ManagerROSE(client, true);
+		settingsRose.setHandler(collector);
+
+		const modules = client.getLoadedModules();
+		assert.equal(modules.size, 1);
+		const module = modules.get(ENetUC_Settings_Manager.MODULE_NAME);
+		assert.ok(module);
+		assert.ok(module.version.length > 0);
+		assert.ok(module.invokes.has(4100));
+		assert.ok(module.invokes.has(4101));
+		assert.ok(module.events.has(4150));
+		assert.ok((module.invokes.get(4100)?.addedUnix ?? 0) > 0);
+		assert.ok((module.invokes.get(4102)?.deprecatedUnix ?? 0) > 0);
+	});
+});
 
 const transportEncodings = [{ label: "JSON", encoding: EASN1TransportEncoding.JSON }, {
 	label: "BER",

--- a/snacc.h
+++ b/snacc.h
@@ -105,7 +105,6 @@ extern "C"
 	extern int gFilterASN1Files;
 	extern int giValidationLevel;
 	extern int giWriteComments;
-	extern int genVersionFile;
 	extern int genTSESMCode;
 	extern int genUTF8Output;
 	extern int genUTF8BOM;

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "7.0.12"
-#define VERSION_RC 7, 0, 12
-#define RELDATE "07.08.2026"
+#define VERSION "7.0.13"
+#define VERSION_RC 7, 0, 13
+#define RELDATE "10.08.2026"
 
 #endif // VERSION_H

--- a/version.h
+++ b/version.h
@@ -3,6 +3,6 @@
 
 #define VERSION "7.0.13"
 #define VERSION_RC 7, 0, 13
-#define RELDATE "10.08.2026"
+#define RELDATE "17.08.2026"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Summary

- **BUILDSYS-637**: Remove `-versionfile` CLI and aggregate `Asn1InterfaceVersion` output; bump esnacc to **7.0.13** (RELDATE 17.08.2026).
- **BUILDSYS-638**: Enforce canonical `@deprecated` successor notation (`-> (none)`, `-> Symbol`, `-> Module::Symbol`, `-> UCWeb::Symbol`) with warn-only validation.
- Extend successor validation to qualified cross-module references when the target module is in the compile set (`UCWeb::` resolves to loaded `EUCWeb_*` modules).
- Skip successor validation on SEQUENCE/ENUMERATED members (context-specific).
- **UCAAS-1481** (WIP on branch): per-stub module/operation registry for C++ and TypeScript ROSE stubs.

## Test plan

- [x] CMake Release build of compiler and `cpp-lib-sample-runtime-tests`
- [x] `deprecated_successor_cli_tests` (7 cases) pass
- [x] Regenerate a representative ASN.1 vcxproj and confirm warn-only successor output
- [x] Verify `esnacc -h` documents successor rules; no `-versionfile` switch
- [x] Confirm `VERSION` / `RELDATE` in `version.h` report 7.0.13 / 17.08.2026