### PR TITLE
UCAAS-1485: per-listener SnaccRoseOperationLookup replaces global registry

### DIFF
--- a/compiler/back-ends/c++-gen/gen-code.c
+++ b/compiler/back-ends/c++-gen/gen-code.c
@@ -4529,6 +4529,7 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	PrintConditionalIncludeOpen(hdrInterface, m->ROSEHdrInterfaceFileName);
 
 	fprintf(hdr, "#include <%sSnaccROSEInterfaces.h>\n", szCppHeaderIncludePath);
+	fprintf(hdr, "#include <%sSnaccRoseOperationLookup.h>\n", szCppHeaderIncludePath);
 
 	fprintf(hdrInterface, "#include <%sSnaccROSEInterfaces.h>\n", szCppHeaderIncludePath);
 	fprintf(hdrInterface, "#include \"%s\"\n", RemovePath(m->ROSEHdrForwardDeclFileName));
@@ -4540,6 +4541,7 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	fprintf(src, "#include \"%s\"\n", RemovePath(m->ROSEHdrInterfaceFileName));
 	fprintf(src, "#include <utility>\n");
 	fprintf(src, "#include <%sSnaccROSEBase.h>\n", szCppHeaderIncludePath);
+	fprintf(src, "#include <%sSnaccRoseOperationLookup.h>\n", szCppHeaderIncludePath);
 	fprintf(src, "#include <%sSNACCROSE.h>\n", szCppHeaderIncludePath);
 	fprintf(src, "#include <%sSNACCDeprecated.h>\n", szCppHeaderIncludePath);
 	if (gMajorInterfaceVersion >= 0)
@@ -4584,24 +4586,21 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	fprintf(hdr, "\t%s(SnaccROSESender* pBase);\n", m->ROSEClassName);
 	fprintf(src, "%s::%s(SnaccROSESender* pBase) : SnaccROSEComponent(pBase)\n", m->ROSEClassName, m->ROSEClassName);
 	fprintf(src, "{\n");
-	fprintf(src, "\tif (m_pSB)\n");
-	fprintf(src, "\t\tRegisterOperations();\n");
 	fprintf(src, "}\n\n");
 
 	// Function for triggering the registration of all Operations (name/id)
-	fprintf(hdr, "\t// Registers all known operations on the ROSE stub instance\n");
-	fprintf(hdr, "\tvoid RegisterOperations();\n");
-	fprintf(src, "void %s::RegisterOperations()\n", m->ROSEClassName);
+	fprintf(hdr, "\t// Registers all known operations on a listener lookup table at startup (UCAAS-1485)\n");
+	fprintf(hdr, "\tstatic void RegisterOperations(SnaccRoseOperationLookup& lookup);\n");
+
+	fprintf(src, "void %s::RegisterOperations(SnaccRoseOperationLookup& lookup)\n", m->ROSEClassName);
 	fprintf(src, "{\n");
-	fprintf(src, "\tif (!m_pSB)\n");
-	fprintf(src, "\t\treturn;\n");
 	if (gMajorInterfaceVersion >= 0)
 	{
 		long long lPatchVersion = GetModulePatchVersion(m->moduleName);
 		char* szNumericDate = ConvertUnixTimeToNumericDate(lPatchVersion);
 		if (szNumericDate)
 		{
-			fprintf(src, "\tRegisterModuleVersion(\"%s\", \"%i.0.%s\");\n", m->moduleName, gMajorInterfaceVersion, szNumericDate);
+			fprintf(src, "\tlookup.RegisterModuleVersion(\"%s\", \"%i.0.%s\");\n", m->moduleName, gMajorInterfaceVersion, szNumericDate);
 			free(szNumericDate);
 		}
 	}
@@ -4609,12 +4608,13 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 	{
 		if (IsDeprecatedNoOutputOperation(m, vd->definedName))
 			continue;
-		if (PrintROSEOperationRegistration(src, r, m, vd) && !iFirstIIDFound)
+		if (PrintROSEOperationRegistrationLookup(src, r, m, vd) && !iFirstIIDFound)
 		{
 			iFirstIIDFound = 1;
 			fprintf(hdr, "\tstatic const int m_iid = %d;\n", vd->value->basicValue->a.integer);
 		}
 	}
+	fprintf(src, "}\n\n");
 
 	if (iFirstIIDFound)
 	{
@@ -4626,7 +4626,6 @@ void PrintROSECode(FILE* src, FILE* hdr, FILE* hdrInterface, ModuleList* mods, M
 		fprintf(hdr, "public:\n");
 	}
 
-	fprintf(src, "}\n\n");
 	fflush(src);
 	fflush(hdr);
 

--- a/compiler/back-ends/c++-gen/gen-code.h
+++ b/compiler/back-ends/c++-gen/gen-code.h
@@ -39,6 +39,7 @@ char* LookupNamespace(Type* t, ModuleList* mods);
 void PrintROSEAnyCode(FILE* src, FILE* hdr, CxxRules* r, ModuleList* mods, Module* m);
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS);
 int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v);
+int PrintROSEOperationRegistrationLookup(FILE* src, CxxRules* r, Module* mod, ValueDef* v);
 
 extern char* bVDAGlobalDLLExport;
 extern int gNO_NAMESPACE;

--- a/compiler/back-ends/c++-gen/gen-vals.c
+++ b/compiler/back-ends/c++-gen/gen-vals.c
@@ -127,6 +127,54 @@ int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef
 	return 1;
 }
 
+int PrintROSEOperationRegistrationLookup(FILE* src, CxxRules* r, Module* mod, ValueDef* v)
+{
+	/* just do ints */
+	if (v->value->basicValue->choiceId != BASICVALUE_INTEGER)
+		return 0;
+
+	if (v->value->type->basicType->choiceId != BASICTYPE_MACROTYPE)
+		return 0;
+
+	if (v->value->type->basicType->a.macroType->choiceId != MACROTYPE_ROSOPERATION)
+		return 0;
+
+	const char* pszArgument = NULL;
+	const char* pszResult = NULL;
+	const char* pszError = NULL;
+	if (!GetROSEDetails(mod, v, &pszArgument, &pszResult, &pszError, NULL, NULL, NULL, false))
+		return 0;
+
+	const bool bIsEvent = pszResult == NULL;
+	unsigned long long ullAddedUnix = 0;
+	unsigned long long ullDeprecatedUnix = 0;
+	asnoperationcomment comment;
+	if (GetOperationComment_UTF8(mod->moduleName, v->definedName, &comment))
+	{
+		if (comment.i64Added > 0)
+			ullAddedUnix = (unsigned long long)comment.i64Added;
+		if (comment.i64Deprecated > 0)
+			ullDeprecatedUnix = (unsigned long long)comment.i64Deprecated;
+	}
+
+	fprintf(src, "\tlookup.RegisterOperation(");
+	fprintf(src, "%d, \"", v->value->basicValue->a.integer);
+	PrintCxxValueDefsName(src, r, v);
+	fprintf(src, "\", m_iid, \"%s\"", mod->moduleName);
+	if (bIsEvent)
+	{
+		if (ullAddedUnix != 0 || ullDeprecatedUnix != 0)
+			fprintf(src, ", true, %lluULL, %lluULL", ullAddedUnix, ullDeprecatedUnix);
+		else
+			fprintf(src, ", true");
+	}
+	else if (ullAddedUnix != 0 || ullDeprecatedUnix != 0)
+		fprintf(src, ", false, %lluULL, %lluULL", ullAddedUnix, ullDeprecatedUnix);
+	fprintf(src, ");\n");
+
+	return 1;
+}
+
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS)
 {
 	/* just do ints */

--- a/compiler/back-ends/c++-gen/gen-vals.h
+++ b/compiler/back-ends/c++-gen/gen-vals.h
@@ -5,5 +5,6 @@ void PrintCxxValueDef(FILE* src, CxxRules* r, ValueDef* v);
 void PrintCxxValueExtern(FILE* hdr, CxxRules* r, ValueDef* v);
 void PrintROSEOperationDefines(FILE* hdr, CxxRules* r, ValueDef* v, int bCS);
 int PrintROSEOperationRegistration(FILE* src, CxxRules* r, Module* mod, ValueDef* v);
+int PrintROSEOperationRegistrationLookup(FILE* src, CxxRules* r, Module* mod, ValueDef* v);
 
 #endif

--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -133,7 +133,8 @@ class SnaccROSEBase;
 		Implement the ISnaccROSETransport:
 		- virtual SendBinaryDataBlockEx should be overwritten and the data should be submitted (e.g. TCP Outbound)
 
-	- During shutdown call StopProcessing to complete any pending operations.
+	- On transport disconnect call PauseRoseProcessing() to complete pending operations.
+	- On a new transport session call ResumeRoseProcessing() before negotiate/login traffic.
 
 	Dependencies:
 	-Snacc lib
@@ -163,11 +164,14 @@ public:
 		Wait time in milliseconds */
 	void SetMaxInvokeWaitTime(long lMaxInvokeWait);
 
-	/*! Shutdown.
-		Call this function to stop processing any more Invokes.
-		All pending operations will be completed and new function calls will be blocked.
-		All Functions return a ROSE_TE_SHUTDOWN */
-	void StopProcessing(bool bStop = true);
+	/*! Ends the current transport ROSE session: blocks new invokes/events and completes
+		pending operations with ROSE_TE_SHUTDOWN. Pair with ResumeRoseProcessing() when
+		the same stub instance reconnects. */
+	void PauseRoseProcessing();
+
+	/*! Re-opens ROSE processing after PauseRoseProcessing() (e.g. transport reconnect).
+		Does not complete or resurrect pending operations from the prior session. */
+	void ResumeRoseProcessing();
 
 	/*! Input of the binary data
 		This processes results and Invokes that are in the list of MultiThreadedInvokeIDs.
@@ -445,7 +449,7 @@ private:
 	const std::wstring m_strClassName;
 	/*! Maximum wait time (milliseconds) for a function to return default: 20000 ms*/
 	long m_lMaxInvokeWait{20000};
-	/*! Are we currently active or was StopProcessing called */
+	/*! False while PauseRoseProcessing() shutdown gate is active for this transport session. */
 	bool m_bProcessingAllowed{true};
 	/*! The counter for the InvokeIds */
 	long m_lInvokeCounter{};

--- a/cpp-lib/include/SnaccROSEBase.h
+++ b/cpp-lib/include/SnaccROSEBase.h
@@ -16,6 +16,7 @@
 #include <wchar.h>
 #include <optional>
 #include "SnaccROSEInterfaces.h"
+#include "SnaccRoseOperationLookup.h"
 #include "SnaccTelemetry.h"
 #include "syncevent.h"
 
@@ -116,24 +117,6 @@ typedef std::map<long, std::unique_ptr<SnaccROSEPendingOperation>> SnaccROSEPend
 
 class SnaccROSEBase;
 
-/*! Per-operation @added / @deprecated metadata (unix seconds; 0 = not annotated). */
-struct SnaccOpVersionInfo
-{
-	unsigned long long m_ullAddedUnix = 0;
-	unsigned long long m_ullDeprecatedUnix = 0;
-};
-
-/*! Loaded module snapshot for negotiate / introspection on one ROSE stub instance. */
-struct SnaccLoadedModuleInfo
-{
-	std::string m_strModuleName;
-	std::string m_strVersion;
-	std::unordered_map<unsigned int, SnaccOpVersionInfo> m_invokes;
-	std::unordered_map<unsigned int, SnaccOpVersionInfo> m_events;
-};
-
-using SnaccLoadedModuleMap = std::unordered_map<std::string, SnaccLoadedModuleInfo>;
-
 #define SNACC_TE_BER SNACC::TransportEncoding::BER
 #define SNACC_TE_JSON SNACC::TransportEncoding::JSON
 
@@ -164,8 +147,9 @@ using SnaccLoadedModuleMap = std::unordered_map<std::string, SnaccLoadedModuleIn
 class SnaccROSEBase : public SnaccROSESender, public SnaccTelemetryCallback
 {
 public:
-	SnaccROSEBase(const wchar_t* szClassName);
-	SnaccROSEBase(const wchar_t* szClassName, const std::set<int>& multithreadInvokeIDs);
+	/*! @p operationLookup is borrowed for the lifetime of this stub (listener-owned, sealed after startup). */
+	SnaccROSEBase(const wchar_t* szClassName, const SnaccRoseOperationLookup& operationLookup);
+	SnaccROSEBase(const wchar_t* szClassName, const SnaccRoseOperationLookup& operationLookup, const std::set<int>& multithreadInvokeIDs);
 	virtual ~SnaccROSEBase(void);
 
 	/*
@@ -223,41 +207,28 @@ public:
 	/* Retrieve the log level - do we need to log something */
 	virtual SNACC::EAsnLogLevel GetLogLevel(const bool bOutbound) override = 0;
 
-	/*! Registers module version wire string (MODULE_VERSION) for this stub instance. */
-	void RegisterModuleVersion(const char* szModuleName, const char* szVersion);
+	/*! Read-only operation lookup shared by this stub (UCAAS-1485). */
+	const SnaccRoseOperationLookup& OperationLookup() const
+	{
+		return m_operationLookup;
+	}
 
-	/*! Registers one ROSE operation (invoke or event) on this stub instance. */
-	void RegisterOperation(
-		unsigned int uiOpID,
-		const char* szOpName,
-		unsigned int uiInterfaceID,
-		const char* szModuleName,
-		bool bIsEvent = false,
-		unsigned long long ullAddedUnix = 0,
-		unsigned long long ullDeprecatedUnix = 0);
+	/*! Startup registration and tests only. Asserts when the lookup table is sealed. */
+	SnaccRoseOperationLookup& OperationLookupForRegistration();
 
-	/*! Removes one operation from this stub registry. */
-	void UnregisterOperation(unsigned int uiOpID);
-
-	/*! Removes a module and all of its operations from this stub registry. */
-	void UnregisterModule(const char* szModuleName);
-
-	/*! Clears all module and operation registrations on this stub (tests / shutdown). */
-	void ClearRegisteredOperations();
-
-	/*! True when at least one operation is registered on this stub. */
+	/*! True when at least one operation is registered on the lookup table. */
 	bool HasRegisteredOperations() const;
 
-	/*! Snapshot of modules and operations registered on this stub. */
+	/*! Snapshot of modules and operations on the lookup table. */
 	const SnaccLoadedModuleMap& GetLoadedModules() const;
 
-	/*! Resolves operation name from operation id on this stub. */
+	/*! Resolves operation name from operation id via the lookup table. */
 	const char* LookUpName(unsigned int uiOpID) const;
 
-	/*! Resolves operation id from operation name on this stub. */
+	/*! Resolves operation id from operation name via the lookup table. */
 	unsigned int LookUpID(const char* szOpName) const;
 
-	/*! Resolves generated interface id (m_iid) from operation id on this stub. */
+	/*! Resolves generated interface id (m_iid) from operation id via the lookup table. */
 	unsigned int LookUpInterfaceID(unsigned int uiOpID) const;
 
 	/*! Writes JSON encoded log messages to the log file
@@ -545,11 +516,8 @@ private:
 	 */
 	long Send(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, SnaccInvokeContext& ctx, size_t* pstRequestData = nullptr);
 
-	std::map<std::string, unsigned int> m_mapOpToID;
-	std::map<unsigned int, std::string> m_mapIDToOp;
-	std::map<unsigned int, unsigned int> m_mapIDToInterface;
-	SnaccLoadedModuleMap m_loadedModules;
-	std::unordered_map<unsigned int, std::pair<std::string, bool>> m_mapIDToModuleKind;
+	// Borrowed listener lookup table; must outlive this stub and be sealed before accepts (UCAAS-1485).
+	const SnaccRoseOperationLookup& m_operationLookup;
 };
 
 #endif //_SnaccROSEBase_h_

--- a/cpp-lib/include/SnaccROSEInterfaces.h
+++ b/cpp-lib/include/SnaccROSEInterfaces.h
@@ -385,18 +385,11 @@ public:
 	}
 
 protected:
-	/*! Registers module version metadata on the ROSE stub referenced by @c m_pSB. */
+	/*! Registers module version metadata on the lookup table referenced by @c m_pSB. */
 	void RegisterModuleVersion(const char* szModuleName, const char* szVersion);
 
-	/*! Registers one ROSE operation on the ROSE stub referenced by @c m_pSB. */
-	void RegisterOperation(
-		unsigned int uiOpID,
-		const char* szOpName,
-		unsigned int uiInterfaceID,
-		const char* szModuleName,
-		bool bIsEvent = false,
-		unsigned long long ullAddedUnix = 0,
-		unsigned long long ullDeprecatedUnix = 0);
+	/*! Registers one ROSE operation on the lookup table referenced by @c m_pSB (UCAAS-1485). */
+	void RegisterOperation(unsigned int uiOpID, const char* szOpName, unsigned int uiInterfaceID, const char* szModuleName, bool bIsEvent = false, unsigned long long ullAddedUnix = 0, unsigned long long ullDeprecatedUnix = 0);
 
 	SnaccROSESender* m_pSB;
 };

--- a/cpp-lib/include/SnaccRoseOperationLookup.h
+++ b/cpp-lib/include/SnaccRoseOperationLookup.h
@@ -1,0 +1,109 @@
+#ifndef _SnaccRoseOperationLookup_h_
+#define _SnaccRoseOperationLookup_h_
+
+/*! UCAAS-1485: per-listener operation lookup table (immutable after Seal). */
+
+#include "SnaccROSEInterfaces.h"
+
+#include <map>
+#include <string>
+#include <unordered_map>
+
+/*! Per-operation @added / @deprecated metadata (unix seconds; 0 = not annotated). */
+struct SnaccOpVersionInfo
+{
+	unsigned long long m_ullAddedUnix = 0;
+	unsigned long long m_ullDeprecatedUnix = 0;
+};
+
+/*! Loaded module snapshot for negotiate / introspection on one lookup table. */
+struct SnaccLoadedModuleInfo
+{
+	std::string m_strModuleName;
+	std::string m_strVersion;
+	std::unordered_map<unsigned int, SnaccOpVersionInfo> m_invokes;
+	std::unordered_map<unsigned int, SnaccOpVersionInfo> m_events;
+};
+
+using SnaccLoadedModuleMap = std::unordered_map<std::string, SnaccLoadedModuleInfo>;
+
+/*! Immutable operation-id lookup table after Seal().
+	Fill at listener startup; share one instance across all connections on that listener.
+	Lookup is read-only and needs no locking once sealed. */
+class SnaccRoseOperationLookup
+{
+public:
+	SnaccRoseOperationLookup() = default;
+
+	/*! Populates module version metadata before Seal(). Used by generated RegisterOperations(). */
+	void RegisterModuleVersion(const char* szModuleName, const char* szVersion);
+
+	/*! Registers one invoke or event before Seal(). Duplicate operation ids are ignored. */
+	void RegisterOperation(
+		unsigned int uiOpID,
+		const char* szOpName,
+		unsigned int uiInterfaceID,
+		const char* szModuleName,
+		bool bIsEvent = false,
+		unsigned long long ullAddedUnix = 0,
+		unsigned long long ullDeprecatedUnix = 0);
+
+	/*! Test-only reset before Seal(). Production tables should Seal() after startup registration. */
+	void ClearRegisteredOperations();
+
+	/*! Freezes the table. Further Register* calls assert in debug and are ignored in release. */
+	void Seal();
+
+	/*! True after Seal() was called. */
+	bool IsSealed() const
+	{
+		return m_bSealed;
+	}
+
+	bool HasRegisteredOperations() const;
+	const SnaccLoadedModuleMap& GetLoadedModules() const;
+
+	const char* LookUpName(unsigned int uiOpID) const;
+	unsigned int LookUpID(const char* szOpName) const;
+	unsigned int LookUpInterfaceID(unsigned int uiOpID) const;
+
+private:
+	bool m_bSealed = false;
+	std::map<std::string, unsigned int> m_mapOpToID;
+	std::map<unsigned int, std::string> m_mapIDToOp;
+	std::map<unsigned int, unsigned int> m_mapIDToInterface;
+	SnaccLoadedModuleMap m_loadedModules;
+	std::unordered_map<unsigned int, std::pair<std::string, bool>> m_mapIDToModuleKind;
+};
+
+/*! Minimal SnaccROSESender used only to drive generated RegisterOperations() at startup.
+	Pass to generated *ROSE(&host) while filling a listener-owned SnaccRoseOperationLookup. */
+class SnaccRoseOperationLookupRegistrationHost : public SnaccROSESender
+{
+public:
+	explicit SnaccRoseOperationLookupRegistrationHost(SnaccRoseOperationLookup& operationLookup);
+
+	SnaccRoseOperationLookup& OperationLookup()
+	{
+		return m_operationLookup;
+	}
+
+	std::shared_ptr<SnaccInvokeContext> CreateInvokeContext(const SnaccInvokeContextInit& init) override;
+	long GetNextInvokeID() override;
+	SNACC::EAsnLogLevel GetLogLevel(const bool bOutbound) override;
+	bool LogTransportData(const bool bOutbound, const SNACC::TransportEncoding encoding, const char* szOperationName, const char* szData, const size_t size, const SNACC::ROSEMessage* pMSg, const SJson::Value* pParsedValue = nullptr) override;
+	long SendInvoke(SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, SNACC::AsnType* pError, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx = {}) override;
+	long SendInvokeAsync(SNACC::ROSEInvoke* pInvoke, SNACC::AsnType* pResult, SNACC::AsnType* pError, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx = {}) override;
+	long HandleInvokeResult(long lRoseResult, const SNACC::ROSEMessage& responseMsg, SNACC::AsnType* pResult, SNACC::AsnType* pError, SnaccInvokeContext& ctx) override;
+	long HandleOnInvokeResult(SNACC::InvokeResult invokeResult, const SNACC::ROSEInvoke& invoke, SnaccInvokeContext& ctx, std::string& strResponse, SNACC::AsnType* pResult, SNACC::AsnType* pError) override;
+	long DecodeInvoke(const SNACC::ROSEMessage& invokeMessage, SNACC::AsnType* pArgument) override;
+	long SendEvent(SNACC::ROSEInvoke* pInvoke, const char* szOperationName, std::shared_ptr<SnaccInvokeContext> pCtx = {}) override;
+	long EncodeResult(unsigned int uiInvokeID, const SNACC::AsnType* pResult, std::string& strResponse, const wchar_t* szSessionID = nullptr) override;
+	long EncodeError(unsigned int uiInvokeID, const SNACC::AsnType* pError, std::string& strResponse, const wchar_t* szSessionID = nullptr) override;
+
+private:
+	SnaccRoseOperationLookup& m_operationLookup;
+	long m_lNextInvokeId = 1;
+};
+
+#endif // _SnaccRoseOperationLookup_h_

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -755,20 +755,25 @@ void SnaccROSEBase::SetTelemetryCallback(SnaccTelemetryCallback* pTelemetryCallB
 
 SnaccROSEBase::~SnaccROSEBase(void)
 {
-	StopProcessing(true);
+	PauseRoseProcessing();
 	StopWatchdogThread();
 	ConfigureFileLogging(nullptr);
 }
 
-void SnaccROSEBase::StopProcessing(bool bStop /*= true*/)
+void SnaccROSEBase::PauseRoseProcessing()
 {
 	{
 		std::lock_guard<std::mutex> guard(m_InternalProtectMutex);
-		m_bProcessingAllowed = bStop ? false : true;
+		m_bProcessingAllowed = false;
 	}
 
-	if (bStop)
-		CompleteAllPendingOperations();
+	CompleteAllPendingOperations();
+}
+
+void SnaccROSEBase::ResumeRoseProcessing()
+{
+	std::lock_guard<std::mutex> guard(m_InternalProtectMutex);
+	m_bProcessingAllowed = true;
 }
 
 void SnaccROSEBase::SetMaxInvokeWaitTime(long lMaxInvokeWait)

--- a/cpp-lib/src/SnaccROSEBase.cpp
+++ b/cpp-lib/src/SnaccROSEBase.cpp
@@ -37,7 +37,7 @@ namespace
 		if (!pStub)
 			return "";
 
-		const char* szLookupName = pStub->LookUpName(uiOperationID);
+		const char* szLookupName = pStub->OperationLookup().LookUpName(uiOperationID);
 		return szLookupName ? szLookupName : "";
 	}
 
@@ -51,7 +51,7 @@ namespace
 		if (!pStub)
 			return "";
 
-		const char* szLookupName = pStub->LookUpName(invoke.operationID);
+		const char* szLookupName = pStub->OperationLookup().LookUpName(invoke.operationID);
 		if (szLookupName)
 			return szLookupName;
 
@@ -65,7 +65,7 @@ namespace
 		if (invoke.operationID || !invoke.operationName)
 			return;
 
-		const unsigned int uiResolvedOperationId = stub.LookUpID(invoke.operationName->getASCII().c_str());
+		const unsigned int uiResolvedOperationId = stub.OperationLookup().LookUpID(invoke.operationName->getASCII().c_str());
 		if (uiResolvedOperationId)
 			invoke.operationID = uiResolvedOperationId;
 	}
@@ -598,18 +598,12 @@ SnaccTelemetryData::Stage GetOutboundUnhandledStageFromResult(const long lRoseRe
 }
 
 // check if at least one Operation has been registerd
-namespace
-{
-SnaccROSEBase* AsRoseBase(SnaccROSESender* pSender)
-{
-	return dynamic_cast<SnaccROSEBase*>(pSender);
-}
-} // namespace
-
 void SnaccROSEComponent::RegisterModuleVersion(const char* szModuleName, const char* szVersion)
 {
-	if (SnaccROSEBase* pStub = AsRoseBase(m_pSB))
-		pStub->RegisterModuleVersion(szModuleName, szVersion);
+	if (auto* pHost = dynamic_cast<SnaccRoseOperationLookupRegistrationHost*>(m_pSB))
+		pHost->OperationLookup().RegisterModuleVersion(szModuleName, szVersion);
+	else if (auto* pStub = dynamic_cast<SnaccROSEBase*>(m_pSB))
+		pStub->OperationLookupForRegistration().RegisterModuleVersion(szModuleName, szVersion);
 }
 
 void SnaccROSEComponent::RegisterOperation(
@@ -621,161 +615,44 @@ void SnaccROSEComponent::RegisterOperation(
 	unsigned long long ullAddedUnix,
 	unsigned long long ullDeprecatedUnix)
 {
-	if (SnaccROSEBase* pStub = AsRoseBase(m_pSB))
-		pStub->RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, bIsEvent, ullAddedUnix, ullDeprecatedUnix);
+	if (auto* pHost = dynamic_cast<SnaccRoseOperationLookupRegistrationHost*>(m_pSB))
+		pHost->OperationLookup().RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, bIsEvent, ullAddedUnix, ullDeprecatedUnix);
+	else if (auto* pStub = dynamic_cast<SnaccROSEBase*>(m_pSB))
+		pStub->OperationLookupForRegistration().RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, bIsEvent, ullAddedUnix, ullDeprecatedUnix);
 }
 
-void SnaccROSEBase::RegisterModuleVersion(const char* szModuleName, const char* szVersion)
+SnaccRoseOperationLookup& SnaccROSEBase::OperationLookupForRegistration()
 {
-	if (!szModuleName || !szVersion)
-		return;
-
-	auto& module = m_loadedModules[szModuleName];
-	module.m_strModuleName = szModuleName;
-	module.m_strVersion = szVersion;
-}
-
-void SnaccROSEBase::RegisterOperation(
-	unsigned int uiOpID,
-	const char* szOpName,
-	unsigned int uiInterfaceID,
-	const char* szModuleName,
-	bool bIsEvent,
-	unsigned long long ullAddedUnix,
-	unsigned long long ullDeprecatedUnix)
-{
-	if (!szOpName || !szModuleName)
-		return;
-
-	if (m_mapIDToOp.find(uiOpID) != m_mapIDToOp.end())
-		return;
-
 #ifdef _DEBUG
-	if (m_mapOpToID.find(szOpName) != m_mapOpToID.end())
-	{
+	if (m_operationLookup.IsSealed())
 		ASSERT(0);
-	}
 #endif
-
-	m_mapOpToID[szOpName] = uiOpID;
-	m_mapIDToOp[uiOpID] = szOpName;
-	m_mapIDToInterface[uiOpID] = uiInterfaceID;
-	m_mapIDToModuleKind[uiOpID] = {szModuleName, bIsEvent};
-
-	auto& module = m_loadedModules[szModuleName];
-	module.m_strModuleName = szModuleName;
-
-	SnaccOpVersionInfo info;
-	info.m_ullAddedUnix = ullAddedUnix;
-	info.m_ullDeprecatedUnix = ullDeprecatedUnix;
-	if (bIsEvent)
-		module.m_events[uiOpID] = info;
-	else
-		module.m_invokes[uiOpID] = info;
-}
-
-void SnaccROSEBase::UnregisterOperation(unsigned int uiOpID)
-{
-	const auto moduleKindIt = m_mapIDToModuleKind.find(uiOpID);
-	if (moduleKindIt != m_mapIDToModuleKind.end())
-	{
-		auto moduleIt = m_loadedModules.find(moduleKindIt->second.first);
-		if (moduleIt != m_loadedModules.end())
-		{
-			if (moduleKindIt->second.second)
-				moduleIt->second.m_events.erase(uiOpID);
-			else
-				moduleIt->second.m_invokes.erase(uiOpID);
-		}
-		m_mapIDToModuleKind.erase(moduleKindIt);
-	}
-
-	const auto idIt = m_mapIDToOp.find(uiOpID);
-	if (idIt != m_mapIDToOp.end())
-	{
-		m_mapOpToID.erase(idIt->second);
-		m_mapIDToOp.erase(idIt);
-	}
-
-	m_mapIDToInterface.erase(uiOpID);
-}
-
-void SnaccROSEBase::UnregisterModule(const char* szModuleName)
-{
-	if (!szModuleName)
-		return;
-
-	std::vector<unsigned int> opIds;
-	for (const auto& entry : m_mapIDToModuleKind)
-	{
-		if (entry.second.first == szModuleName)
-			opIds.push_back(entry.first);
-	}
-
-	for (const unsigned int uiOpID : opIds)
-		UnregisterOperation(uiOpID);
-
-	m_loadedModules.erase(szModuleName);
-}
-
-void SnaccROSEBase::ClearRegisteredOperations()
-{
-	m_mapOpToID.clear();
-	m_mapIDToOp.clear();
-	m_mapIDToInterface.clear();
-	m_mapIDToModuleKind.clear();
-	m_loadedModules.clear();
+	return const_cast<SnaccRoseOperationLookup&>(m_operationLookup);
 }
 
 bool SnaccROSEBase::HasRegisteredOperations() const
 {
-	return !m_mapIDToOp.empty();
+	return m_operationLookup.HasRegisteredOperations();
 }
 
 const SnaccLoadedModuleMap& SnaccROSEBase::GetLoadedModules() const
 {
-	return m_loadedModules;
+	return m_operationLookup.GetLoadedModules();
 }
 
 const char* SnaccROSEBase::LookUpName(unsigned int uiOpID) const
 {
-	const auto it = m_mapIDToOp.find(uiOpID);
-	if (it != m_mapIDToOp.end())
-		return it->second.c_str();
-
-#ifdef _DEBUG
-	static std::mutex s_mutex;
-	static std::set<int> s_unknownOpIDsAlreadyNotified;
-	std::lock_guard<std::mutex> lock(s_mutex);
-	if (!s_unknownOpIDsAlreadyNotified.contains(uiOpID))
-	{
-		s_unknownOpIDsAlreadyNotified.insert(uiOpID);
-		fprintf(stderr, "An unknown operation with operationID %d was called.\n", uiOpID);
-	}
-#endif
-
-	return nullptr;
+	return m_operationLookup.LookUpName(uiOpID);
 }
 
 unsigned int SnaccROSEBase::LookUpID(const char* szOpName) const
 {
-	if (!szOpName)
-		return 0;
-
-	const auto it = m_mapOpToID.find(szOpName);
-	if (it != m_mapOpToID.end())
-		return it->second;
-
-	return 0;
+	return m_operationLookup.LookUpID(szOpName);
 }
 
 unsigned int SnaccROSEBase::LookUpInterfaceID(unsigned int uiOpID) const
 {
-	const auto it = m_mapIDToInterface.find(uiOpID);
-	if (it != m_mapIDToInterface.end())
-		return it->second;
-
-	return 0;
+	return m_operationLookup.LookUpInterfaceID(uiOpID);
 }
 
 SnaccROSEPendingOperation::SnaccROSEPendingOperation(long lInvokeID, unsigned int uiOperationID, const char* szOperationName)
@@ -858,13 +735,15 @@ void SnaccROSEPendingOperation::FinalizeTelemetry(long lFinalRoseResult, std::sh
 	m_pTelemetry->finalize(SnaccTelemetryData::Outcome::DISPATCHED, SnaccTelemetryData::Stage::OUTBOUND_WAIT, SnaccTelemetryData::Reason::WAIT_SKIPPED, m_lRoseResult, std::nullopt, std::move(pctx));
 }
 
-SnaccROSEBase::SnaccROSEBase(const wchar_t* szClassName)
-	: m_strClassName(szClassName)
+SnaccROSEBase::SnaccROSEBase(const wchar_t* szClassName, const SnaccRoseOperationLookup& operationLookup)
+	: m_strClassName(szClassName),
+	  m_operationLookup(operationLookup)
 {
 }
 
-SnaccROSEBase::SnaccROSEBase(const wchar_t* szClassName, const std::set<int>& multithreadInvokeIDs)
+SnaccROSEBase::SnaccROSEBase(const wchar_t* szClassName, const SnaccRoseOperationLookup& operationLookup, const std::set<int>& multithreadInvokeIDs)
 	: m_strClassName(szClassName),
+	  m_operationLookup(operationLookup),
 	  m_multithreadInvokeIDs(multithreadInvokeIDs)
 {
 }

--- a/cpp-lib/src/SnaccRoseOperationLookup.cpp
+++ b/cpp-lib/src/SnaccRoseOperationLookup.cpp
@@ -1,0 +1,210 @@
+#include "../include/SnaccRoseOperationLookup.h"
+#include "../include/SNACCROSE.h"
+#include "snacc-assert.h"
+
+#include <cstdio>
+#include <mutex>
+#include <set>
+
+namespace
+{
+void AssertNotSealed(const SnaccRoseOperationLookup& lookup)
+{
+#ifdef _DEBUG
+	if (lookup.IsSealed())
+	{
+		ASSERT(0);
+	}
+#endif
+	(void)lookup;
+}
+} // namespace
+
+void SnaccRoseOperationLookup::RegisterModuleVersion(const char* szModuleName, const char* szVersion)
+{
+	if (!szModuleName || !szVersion || m_bSealed)
+		return;
+
+	AssertNotSealed(*this);
+
+	auto& module = m_loadedModules[szModuleName];
+	module.m_strModuleName = szModuleName;
+	module.m_strVersion = szVersion;
+}
+
+void SnaccRoseOperationLookup::RegisterOperation(
+	unsigned int uiOpID,
+	const char* szOpName,
+	unsigned int uiInterfaceID,
+	const char* szModuleName,
+	bool bIsEvent,
+	unsigned long long ullAddedUnix,
+	unsigned long long ullDeprecatedUnix)
+{
+	if (!szOpName || !szModuleName || m_bSealed)
+		return;
+
+	AssertNotSealed(*this);
+
+	if (m_mapIDToOp.find(uiOpID) != m_mapIDToOp.end())
+		return;
+
+#ifdef _DEBUG
+	if (m_mapOpToID.find(szOpName) != m_mapOpToID.end())
+	{
+		ASSERT(0);
+	}
+#endif
+
+	m_mapOpToID[szOpName] = uiOpID;
+	m_mapIDToOp[uiOpID] = szOpName;
+	m_mapIDToInterface[uiOpID] = uiInterfaceID;
+	m_mapIDToModuleKind[uiOpID] = {szModuleName, bIsEvent};
+
+	auto& module = m_loadedModules[szModuleName];
+	module.m_strModuleName = szModuleName;
+
+	SnaccOpVersionInfo info;
+	info.m_ullAddedUnix = ullAddedUnix;
+	info.m_ullDeprecatedUnix = ullDeprecatedUnix;
+	if (bIsEvent)
+		module.m_events[uiOpID] = info;
+	else
+		module.m_invokes[uiOpID] = info;
+}
+
+void SnaccRoseOperationLookup::ClearRegisteredOperations()
+{
+	if (m_bSealed)
+		return;
+
+	AssertNotSealed(*this);
+
+	m_mapOpToID.clear();
+	m_mapIDToOp.clear();
+	m_mapIDToInterface.clear();
+	m_mapIDToModuleKind.clear();
+	m_loadedModules.clear();
+}
+
+void SnaccRoseOperationLookup::Seal()
+{
+	m_bSealed = true;
+}
+
+bool SnaccRoseOperationLookup::HasRegisteredOperations() const
+{
+	return !m_mapIDToOp.empty();
+}
+
+const SnaccLoadedModuleMap& SnaccRoseOperationLookup::GetLoadedModules() const
+{
+	return m_loadedModules;
+}
+
+const char* SnaccRoseOperationLookup::LookUpName(unsigned int uiOpID) const
+{
+	const auto it = m_mapIDToOp.find(uiOpID);
+	if (it != m_mapIDToOp.end())
+		return it->second.c_str();
+
+#ifdef _DEBUG
+	static std::mutex s_mutex;
+	static std::set<int> s_unknownOpIDsAlreadyNotified;
+	std::lock_guard<std::mutex> lock(s_mutex);
+	if (!s_unknownOpIDsAlreadyNotified.contains(uiOpID))
+	{
+		s_unknownOpIDsAlreadyNotified.insert(uiOpID);
+		fprintf(stderr, "An unknown operation with operationID %d was called.\n", uiOpID);
+	}
+#endif
+
+	return nullptr;
+}
+
+unsigned int SnaccRoseOperationLookup::LookUpID(const char* szOpName) const
+{
+	if (!szOpName)
+		return 0;
+
+	const auto it = m_mapOpToID.find(szOpName);
+	if (it != m_mapOpToID.end())
+		return it->second;
+
+	return 0;
+}
+
+unsigned int SnaccRoseOperationLookup::LookUpInterfaceID(unsigned int uiOpID) const
+{
+	const auto it = m_mapIDToInterface.find(uiOpID);
+	if (it != m_mapIDToInterface.end())
+		return it->second;
+
+	return 0;
+}
+
+SnaccRoseOperationLookupRegistrationHost::SnaccRoseOperationLookupRegistrationHost(SnaccRoseOperationLookup& operationLookup)
+	: m_operationLookup(operationLookup)
+{
+}
+
+std::shared_ptr<SnaccInvokeContext> SnaccRoseOperationLookupRegistrationHost::CreateInvokeContext(const SnaccInvokeContextInit& init)
+{
+	return SnaccInvokeContext::Create(init);
+}
+
+long SnaccRoseOperationLookupRegistrationHost::GetNextInvokeID()
+{
+	return m_lNextInvokeId++;
+}
+
+SNACC::EAsnLogLevel SnaccRoseOperationLookupRegistrationHost::GetLogLevel(const bool /* bOutbound */)
+{
+	return SNACC::EAsnLogLevel::DISABLED;
+}
+
+bool SnaccRoseOperationLookupRegistrationHost::LogTransportData(const bool /* bOutbound */, const SNACC::TransportEncoding /* encoding */, const char* /* szOperationName */, const char* /* szData */, const size_t /* size */, const SNACC::ROSEMessage* /* pMSg */, const SJson::Value* /* pParsedValue */)
+{
+	return false;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::SendInvoke(SNACC::ROSEInvoke* /* pInvoke */, SNACC::AsnType* /* pResult */, SNACC::AsnType* /* pError */, const char* /* szOperationName */, std::shared_ptr<SnaccInvokeContext> /* pCtx */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::SendInvokeAsync(SNACC::ROSEInvoke* /* pInvoke */, SNACC::AsnType* /* pResult */, SNACC::AsnType* /* pError */, const char* /* szOperationName */, std::shared_ptr<SnaccInvokeContext> /* pCtx */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::HandleInvokeResult(long /* lRoseResult */, const SNACC::ROSEMessage& /* responseMsg */, SNACC::AsnType* /* pResult */, SNACC::AsnType* /* pError */, SnaccInvokeContext& /* ctx */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::HandleOnInvokeResult(SNACC::InvokeResult /* invokeResult */, const SNACC::ROSEInvoke& /* invoke */, SnaccInvokeContext& /* ctx */, std::string& /* strResponse */, SNACC::AsnType* /* pResult */, SNACC::AsnType* /* pError */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::DecodeInvoke(const SNACC::ROSEMessage& /* invokeMessage */, SNACC::AsnType* /* pArgument */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::SendEvent(SNACC::ROSEInvoke* /* pInvoke */, const char* /* szOperationName */, std::shared_ptr<SnaccInvokeContext> /* pCtx */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::EncodeResult(unsigned int /* uiInvokeID */, const SNACC::AsnType* /* pResult */, std::string& /* strResponse */, const wchar_t* /* szSessionID */)
+{
+	return ROSE_TE_SHUTDOWN;
+}
+
+long SnaccRoseOperationLookupRegistrationHost::EncodeError(unsigned int uiInvokeID, const SNACC::AsnType* /* pError */, std::string& /* strResponse */, const wchar_t* /* szSessionID */)
+{
+	(void)uiInvokeID;
+	return ROSE_TE_SHUTDOWN;
+}

--- a/cpp-lib/tests/async_invoke_tests.cpp
+++ b/cpp-lib/tests/async_invoke_tests.cpp
@@ -142,7 +142,7 @@ protected:
 		EXPECT_EQ(1, latch.CallbackCount());
 	}
 
-	void AssertStopProcessingCompletesAsyncInvokeWithShutdown(const TransportEncoding encoding)
+	void AssertPauseRoseProcessingCompletesAsyncInvokeWithShutdown(const TransportEncoding encoding)
 	{
 		InitializeEndpoints(encoding);
 		m_server.Transport().EnqueueAction(TransportAction::Queue());
@@ -155,7 +155,7 @@ protected:
 		ASSERT_EQ(ROSE_NOERROR, sendResult);
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(25));
-		m_client.StopProcessing(true);
+		m_client.PauseRoseProcessing();
 
 		ASSERT_TRUE(latch.WaitFor(std::chrono::milliseconds(500)));
 		EXPECT_EQ(ROSE_TE_SHUTDOWN, latch.RoseResult());
@@ -214,9 +214,9 @@ TEST_F(AsyncInvokeRuntimeTest, LateAsyncResponseIsIgnoredAfterTimeoutBer)
 	AssertLateAsyncResponseIsIgnoredAfterTimeout(TransportEncoding::BER);
 }
 
-TEST_F(AsyncInvokeRuntimeTest, StopProcessingCompletesAsyncInvokeWithShutdownJson)
+TEST_F(AsyncInvokeRuntimeTest, PauseRoseProcessingCompletesAsyncInvokeWithShutdownJson)
 {
-	AssertStopProcessingCompletesAsyncInvokeWithShutdown(TransportEncoding::JSON);
+	AssertPauseRoseProcessingCompletesAsyncInvokeWithShutdown(TransportEncoding::JSON);
 }
 
 TEST_F(AsyncInvokeRuntimeTest, AsyncSendFailureIsReportedBer)

--- a/cpp-lib/tests/invoke_context_tests.cpp
+++ b/cpp-lib/tests/invoke_context_tests.cpp
@@ -229,7 +229,8 @@ namespace sample_runtime_tests
 
 		void AssertNoTransportReturnsTransportFailedForInvoke(const TransportEncoding encoding)
 		{
-			ObservedRuntimeEndpoint endpoint{L"NoTransportEndpoint", "solo-session"};
+			SnaccRoseOperationLookup lookup;
+			ObservedRuntimeEndpoint endpoint{L"NoTransportEndpoint", "solo-session", lookup};
 			endpoint.SetEncoding(encoding);
 			SettingsServiceModule serviceModule(endpoint);
 			ENetUC_Settings_ManagerROSE component(&endpoint);
@@ -249,7 +250,8 @@ namespace sample_runtime_tests
 
 		void AssertNoTransportReturnsTransportFailedForEvent(const TransportEncoding encoding)
 		{
-			ObservedRuntimeEndpoint endpoint{L"NoTransportEndpoint", "solo-session"};
+			SnaccRoseOperationLookup lookup;
+			ObservedRuntimeEndpoint endpoint{L"NoTransportEndpoint", "solo-session", lookup};
 			endpoint.SetEncoding(encoding);
 			SettingsServiceModule serviceModule(endpoint);
 			ENetUC_Settings_ManagerROSE component(&endpoint);
@@ -748,7 +750,8 @@ namespace sample_runtime_tests
 
 	TEST(InvokeContextInitTest, InboundInitResolvesOperationNameFromInvokeLookup)
 	{
-		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session"};
+		SnaccRoseOperationLookup lookup;
+		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session", lookup};
 		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", false);
 
 		ROSEInvoke invoke;
@@ -768,7 +771,8 @@ namespace sample_runtime_tests
 
 	TEST(InvokeContextInitTest, InboundResolvesOperationIdFromNameThenCanonicalContextName)
 	{
-		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session"};
+		SnaccRoseOperationLookup lookup;
+		RuntimeEndpoint endpoint{L"InvokeContextLookup", "invoke-context-session", lookup};
 		endpoint.RegisterOperation(43210, "asnTestInboundName", 1, "TestModule", false);
 
 		ROSEInvoke invoke;

--- a/cpp-lib/tests/lifecycle_tests.cpp
+++ b/cpp-lib/tests/lifecycle_tests.cpp
@@ -8,14 +8,14 @@ class LifecycleRuntimeTest : public RuntimeTestBase
 {
 protected:
 	// Verifies that stopping the client runtime completes a blocked invoke with shutdown.
-	void AssertStopProcessingCompletesPendingInvokeWithShutdown(const TransportEncoding encoding)
+	void AssertPauseRoseProcessingCompletesPendingInvokeWithShutdown(const TransportEncoding encoding)
 	{
 		InitializeEndpoints(encoding);
 		m_server.Transport().EnqueueAction(TransportAction::Queue());
 		auto pendingInvoke = InvokeGetSettingsAsync(1000);
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(25));
-		m_client.StopProcessing(true);
+		m_client.PauseRoseProcessing();
 
 		EXPECT_EQ(ROSE_TE_SHUTDOWN, pendingInvoke.get());
 	}
@@ -36,15 +36,15 @@ protected:
 };
 
 // Runs the shutdown-during-pending-invoke scenario over BER.
-TEST_F(LifecycleRuntimeTest, StopProcessingCompletesPendingInvokeWithShutdownBer)
+TEST_F(LifecycleRuntimeTest, PauseRoseProcessingCompletesPendingInvokeWithShutdownBer)
 {
-	AssertStopProcessingCompletesPendingInvokeWithShutdown(TransportEncoding::BER);
+	AssertPauseRoseProcessingCompletesPendingInvokeWithShutdown(TransportEncoding::BER);
 }
 
 // Runs the shutdown-during-pending-invoke scenario over JSON.
-TEST_F(LifecycleRuntimeTest, StopProcessingCompletesPendingInvokeWithShutdownJson)
+TEST_F(LifecycleRuntimeTest, PauseRoseProcessingCompletesPendingInvokeWithShutdownJson)
 {
-	AssertStopProcessingCompletesPendingInvokeWithShutdown(TransportEncoding::JSON);
+	AssertPauseRoseProcessingCompletesPendingInvokeWithShutdown(TransportEncoding::JSON);
 }
 
 // Runs the fresh-fixture recovery scenario over BER.

--- a/cpp-lib/tests/module_registry_tests.cpp
+++ b/cpp-lib/tests/module_registry_tests.cpp
@@ -22,11 +22,14 @@ void ExpectOpInfo(const SnaccOpVersionInfo& info, const bool bExpectAdded, const
 }
 } // namespace
 
-TEST(ModuleRegistryTest, GeneratedModuleRegistersOnlyOnMountedStub)
+TEST(ModuleRegistryTest, StaticRegistrationPopulatesOnlyTargetLookup)
 {
-	RuntimeEndpoint endpointA{L"RegistryEndpointA", "registry-a"};
-	RuntimeEndpoint endpointB{L"RegistryEndpointB", "registry-b"};
+	SnaccRoseOperationLookup lookupA;
+	SnaccRoseOperationLookup lookupB;
+	RuntimeEndpoint endpointA{L"RegistryEndpointA", "registry-a", lookupA};
+	RuntimeEndpoint endpointB{L"RegistryEndpointB", "registry-b", lookupB};
 
+	ENetUC_Settings_ManagerROSE::RegisterOperations(lookupA);
 	ENetUC_Settings_ManagerROSE settingsOnA(&endpointA);
 
 	EXPECT_TRUE(endpointA.HasRegisteredOperations());
@@ -48,7 +51,9 @@ TEST(ModuleRegistryTest, GeneratedModuleRegistersOnlyOnMountedStub)
 
 TEST(ModuleRegistryTest, RegisteredMetadataMatchesLoadedModuleSnapshot)
 {
-	RuntimeEndpoint endpoint{L"RegistryMetadata", "registry-metadata"};
+	SnaccRoseOperationLookup lookup;
+	RuntimeEndpoint endpoint{L"RegistryMetadata", "registry-metadata", lookup};
+	ENetUC_Settings_ManagerROSE::RegisterOperations(lookup);
 	ENetUC_Settings_ManagerROSE settings(&endpoint);
 
 	const auto& modules = endpoint.GetLoadedModules();
@@ -75,8 +80,10 @@ TEST(ModuleRegistryTest, RegisteredMetadataMatchesLoadedModuleSnapshot)
 
 TEST(ModuleRegistryTest, RuntimeFixtureKeepsClientAndServerRegistriesSeparate)
 {
-	RuntimeEndpoint server{L"RegistryServer", "registry-server"};
-	RuntimeEndpoint client{L"RegistryClient", "registry-client"};
+	SnaccRoseOperationLookup serverLookup;
+	SnaccRoseOperationLookup clientLookup;
+	RuntimeEndpoint server{L"RegistryServer", "registry-server", serverLookup};
+	RuntimeEndpoint client{L"RegistryClient", "registry-client", clientLookup};
 	server.ConnectTo(client);
 	client.ConnectTo(server);
 

--- a/cpp-lib/tests/public_api_tests.cpp
+++ b/cpp-lib/tests/public_api_tests.cpp
@@ -33,7 +33,10 @@ struct DecodeErrorObservation
 class DecodeObservedRuntimeEndpoint : public ObservedRuntimeEndpoint
 {
 public:
-	using ObservedRuntimeEndpoint::ObservedRuntimeEndpoint;
+	DecodeObservedRuntimeEndpoint(const wchar_t* className, const std::string& sessionId, SnaccRoseOperationLookup& operationLookup)
+		: ObservedRuntimeEndpoint(className, sessionId, operationLookup)
+	{
+	}
 
 	void ClearDecodeErrors()
 	{
@@ -89,7 +92,8 @@ std::string GetMalformedPayloadForApiTest(const TransportEncoding encoding)
 
 void AssertOnBinaryDataBlockResultDecodeErrorsInvokeHook(const TransportEncoding encoding)
 {
-	DecodeObservedRuntimeEndpoint endpoint{L"DecodeHookEndpoint", "decode-hook-session"};
+	SnaccRoseOperationLookup lookup;
+	DecodeObservedRuntimeEndpoint endpoint{L"DecodeHookEndpoint", "decode-hook-session", lookup};
 	endpoint.SetTransportEncoding(encoding);
 	endpoint.SetLogLevels(EAsnLogLevel::JSON_AND_BER, EAsnLogLevel::JSON_AND_BER);
 
@@ -172,7 +176,8 @@ protected:
 
 TEST(PublicApiSmokeTest, TransportEncodingCanBeSetAndReadBack)
 {
-	ObservedRuntimeEndpoint endpoint{L"ApiEndpoint", "api-session"};
+	SnaccRoseOperationLookup lookup;
+	ObservedRuntimeEndpoint endpoint{L"ApiEndpoint", "api-session", lookup};
 
 	EXPECT_TRUE(endpoint.SetTransportEncoding(TransportEncoding::BER));
 	EXPECT_EQ(TransportEncoding::BER, endpoint.GetTransportEncoding());
@@ -182,7 +187,8 @@ TEST(PublicApiSmokeTest, TransportEncodingCanBeSetAndReadBack)
 
 TEST(PublicApiSmokeTest, SetSnaccROSETransportRoutesOutboundBytes)
 {
-	ObservedRuntimeEndpoint endpoint{L"TransportEndpoint", "transport-session"};
+	SnaccRoseOperationLookup lookup;
+	ObservedRuntimeEndpoint endpoint{L"TransportEndpoint", "transport-session", lookup};
 	TransportProbe transport;
 	endpoint.SetTransportEncoding(TransportEncoding::JSON_NO_HEADING);
 	endpoint.SetSnaccROSETransport(&transport);
@@ -259,7 +265,8 @@ TEST_F(PublicApiRuntimeTest, StopProcessingBlocksInboundDispatchUntilReEnabled)
 
 TEST(PublicApiSmokeTest, ConfigureFileLoggingWritesAndCanBeDisabled)
 {
-	ObservedRuntimeEndpoint endpoint{L"FileLoggingEndpoint", "file-session"};
+	SnaccRoseOperationLookup lookup;
+	ObservedRuntimeEndpoint endpoint{L"FileLoggingEndpoint", "file-session", lookup};
 	TransportProbe transport;
 	endpoint.SetTransportEncoding(TransportEncoding::JSON_NO_HEADING);
 	endpoint.SetSnaccROSETransport(&transport);
@@ -291,7 +298,8 @@ TEST(PublicApiSmokeTest, ConfigureFileLoggingWritesAndCanBeDisabled)
 
 TEST(PublicApiSmokeTest, OperationLookupRegistersAndCleansUp)
 {
-	ObservedRuntimeEndpoint endpoint{L"LookupEndpoint", "lookup-session"};
+	SnaccRoseOperationLookup lookup;
+	ObservedRuntimeEndpoint endpoint{L"LookupEndpoint", "lookup-session", lookup};
 	EXPECT_FALSE(endpoint.HasRegisteredOperations());
 
 	endpoint.RegisterOperation(3210, "testOperation", 77, "TestModule", false);
@@ -306,6 +314,19 @@ TEST(PublicApiSmokeTest, OperationLookupRegistersAndCleansUp)
 	EXPECT_EQ(0u, endpoint.LookUpID("testOperation"));
 	EXPECT_EQ(nullptr, endpoint.LookUpName(3210));
 	EXPECT_EQ(0u, endpoint.LookUpInterfaceID(3210));
+}
+
+TEST(PublicApiSmokeTest, OperationLookupIgnoresRegistrationAfterSeal)
+{
+	SnaccRoseOperationLookup lookup;
+	lookup.RegisterOperation(100u, "asnBeforeSeal", 1u, "TestModule", false);
+	lookup.Seal();
+	EXPECT_TRUE(lookup.IsSealed());
+	EXPECT_STREQ("asnBeforeSeal", lookup.LookUpName(100u));
+
+	lookup.RegisterOperation(200u, "asnAfterSeal", 1u, "TestModule", false);
+	EXPECT_EQ(nullptr, lookup.LookUpName(200u));
+	EXPECT_EQ(0u, lookup.LookUpID("asnAfterSeal"));
 }
 
 TEST(PublicApiSmokeTest, TelemetryDebugTextCoversGroupedRejectReasons)

--- a/cpp-lib/tests/public_api_tests.cpp
+++ b/cpp-lib/tests/public_api_tests.cpp
@@ -223,10 +223,10 @@ TEST(PublicApiSmokeTest, OnBinaryDataBlockResultDecodeErrorsInvokeHookJson)
 	AssertOnBinaryDataBlockResultDecodeErrorsInvokeHook(TransportEncoding::JSON);
 }
 
-TEST_F(PublicApiRuntimeTest, StopProcessingBlocksNewOutboundInvokesAndEvents)
+TEST_F(PublicApiRuntimeTest, PauseRoseProcessingBlocksNewOutboundInvokesAndEvents)
 {
 	InitializeEndpoints(TransportEncoding::JSON);
-	m_client.StopProcessing(true);
+	m_client.PauseRoseProcessing();
 
 	AsnGetSettingsArgument argument;
 	AsnGetSettingsResult result;
@@ -242,10 +242,10 @@ TEST_F(PublicApiRuntimeTest, StopProcessingBlocksNewOutboundInvokesAndEvents)
 	EXPECT_EQ(ROSE_TE_SHUTDOWN, eventResult);
 }
 
-TEST_F(PublicApiRuntimeTest, StopProcessingBlocksInboundDispatchUntilReEnabled)
+TEST_F(PublicApiRuntimeTest, PauseRoseProcessingBlocksInboundDispatchUntilResumed)
 {
 	InitializeEndpoints(TransportEncoding::JSON);
-	m_server.StopProcessing(true);
+	m_server.PauseRoseProcessing();
 
 	AsnSetSettingsArgument argument;
 	SetSettingsValues(argument.settings, true, "server-should-ignore");
@@ -256,7 +256,7 @@ TEST_F(PublicApiRuntimeTest, StopProcessingBlocksInboundDispatchUntilReEnabled)
 	EXPECT_NE(ROSE_NOERROR, blockedResult);
 	EXPECT_EQ(0, ClientSettingsEventCount());
 
-	m_server.StopProcessing(false);
+	m_server.ResumeRoseProcessing();
 
 	const long resumedResult = m_clientSettingsModule.InvokeSetSettings(&argument, &result, &error, 250);
 	EXPECT_EQ(ROSE_NOERROR, resumedResult);

--- a/cpp-lib/tests/runtime_correctness_notes.md
+++ b/cpp-lib/tests/runtime_correctness_notes.md
@@ -32,7 +32,7 @@ Primary reference points:
 
 | Area | Status | Semantics | Primary tests |
 | --- | --- | --- | --- |
-| `StopProcessing()` shutdown gate | Implemented | Refuse new outbound work; block inbound handler dispatch; complete pending ops with `ROSE_TE_SHUTDOWN` | `PublicApiRuntimeTest.StopProcessingBlocks*`, `LifecycleRuntimeTest.StopProcessing*` |
+| Transport-session ROSE gate | Implemented | `PauseRoseProcessing` / `ResumeRoseProcessing` | `PublicApiRuntimeTest.PauseRoseProcessingBlocks*`, `LifecycleRuntimeTest.PauseRoseProcessing*` |
 | Fire-and-forget (`iTimeout == 0`) telemetry | Implemented | `Outcome::DISPATCHED` + `Reason::WAIT_SKIPPED`, not `UNHANDLED` | `TelemetryRuntimeTest.WaitSkippedTelemetry*` |
 | Response payload decode telemetry | Implemented | Caller-visible `ROSE_RE_DECODE_FAILED` drives `UNHANDLED` + `DECODE_FAILED`, not envelope kind | `TelemetryRuntimeTest.*PayloadDecodeFailureTelemetry*` |
 | Inbound decode failures and ROSE rejects | Implemented | Garbage wire silent; targeted reject only after envelope decode | `InvokeContextRuntimeTest.UnparsableInbound*`, section 5 |
@@ -40,25 +40,22 @@ Primary reference points:
 | Inbound `ROSEMessage` ownership | Implemented | `unique_ptr` at decode sites; `std::move` through dispatch | Section 6; `InvokeContextRuntimeTest` suite |
 | Outbound encode / `Send()` ownership | Implemented | RAII encode helpers detach borrowed arms on scope exit (including encode exceptions) | Section 7; outbound encode-failure tests in `InvokeContextRuntimeTest` |
 
-## 1. `StopProcessing()` Shutdown Contract
+## 1. Transport-session ROSE processing gate (`PauseRoseProcessing` / `ResumeRoseProcessing`)
 
 ### Status: implemented
 
 ### Public contract
 
-`SnaccROSEBase` documents shutdown as a hard stop:
+Preferred API on `SnaccROSEBase`:
 
-```152:156:cpp-lib/include/SnaccROSEBase.h
-	/*! Shutdown.
-		Call this function to stop processing any more Invokes.
-		All pending operations will be completed and new function calls will be blocked.
-		All Functions return a ROSE_TE_SHUTDOWN */
-	void StopProcessing(bool bStop = true);
-```
+- `PauseRoseProcessing()` — end the current transport ROSE session (block new
+  work, complete pending ops with `ROSE_TE_SHUTDOWN`).
+- `ResumeRoseProcessing()` — reopen processing on the same stub instance (e.g.
+  after transport reconnect). Does not resurrect ops from the prior session.
 
 ### Intended behavior
 
-Treat `StopProcessing(true)` as a real runtime shutdown gate:
+Treat `PauseRoseProcessing()` as a transport-session shutdown gate:
 
 1. New outbound invokes and events must fail fast with `ROSE_TE_SHUTDOWN`.
 2. Pending operations must still be completed with `ROSE_TE_SHUTDOWN`.
@@ -66,29 +63,15 @@ Treat `StopProcessing(true)` as a real runtime shutdown gate:
    handlers while shutdown is active.
 4. Late inbound responses that arrive after pending operations were force-
    completed may be ignored, but they must not resurrect completed work.
-5. `StopProcessing(false)` re-enables processing; callers must treat that as an
-   explicit restart, not an incidental side effect.
+5. `ResumeRoseProcessing()` re-enables processing; callers must invoke it
+   explicitly when starting a new transport session on a reused stub (pair with
+   `PauseRoseProcessing()` on disconnect).
 
 ### Implementation
 
-`StopProcessing(true)` clears `m_bProcessingAllowed` and completes all pending
-operations with `ROSE_TE_SHUTDOWN`:
-
-```605:628:cpp-lib/src/SnaccROSEBase.cpp
-void SnaccROSEBase::StopProcessing(bool bStop /*= true*/)
-{
-	{
-		std::lock_guard<std::mutex> guard(m_InternalProtectMutex);
-		m_bProcessingAllowed = bStop ? false : true;
-	}
-
-	if (bStop)
-		CompleteAllPendingOperations();
-}
-...
-	for (auto it = m_PendingOperations.begin(); it != m_PendingOperations.end(); it++)
-		it->second->CompleteOperation(ROSE_TE_SHUTDOWN);
-```
+`PauseRoseProcessing()` clears `m_bProcessingAllowed` and completes all pending
+operations with `ROSE_TE_SHUTDOWN`. `ResumeRoseProcessing()` sets
+`m_bProcessingAllowed` back to true without touching pending operations.
 
 Outbound choke points check `IsProcessingAllowed()` before creating pending
 operations or sending:
@@ -117,10 +100,10 @@ while shutdown is active.
 
 ### Tests that enforce this
 
-- `PublicApiRuntimeTest.StopProcessingBlocksNewOutboundInvokesAndEvents`
-- `PublicApiRuntimeTest.StopProcessingBlocksInboundDispatchUntilReEnabled`
-- `LifecycleRuntimeTest.StopProcessingCompletesPendingInvokeWithShutdownBer`
-- `LifecycleRuntimeTest.StopProcessingCompletesPendingInvokeWithShutdownJson`
+- `PublicApiRuntimeTest.PauseRoseProcessingBlocksNewOutboundInvokesAndEvents`
+- `PublicApiRuntimeTest.PauseRoseProcessingBlocksInboundDispatchUntilResumed`
+- `LifecycleRuntimeTest.PauseRoseProcessingCompletesPendingInvokeWithShutdownBer`
+- `LifecycleRuntimeTest.PauseRoseProcessingCompletesPendingInvokeWithShutdownJson`
 - `LifecycleRuntimeTest.PendingInvokeCanRecoverAfterShutdownOnNextFixtureSetupBer`
 - `LifecycleRuntimeTest.PendingInvokeCanRecoverAfterShutdownOnNextFixtureSetupJson`
 

--- a/cpp-lib/tests/runtime_correctness_notes.md
+++ b/cpp-lib/tests/runtime_correctness_notes.md
@@ -398,9 +398,12 @@ Each helper detaches borrowed pointers in its destructor.
    outbound stubs default to `CreateInvokeContext(SnaccInvokeContextInit(OUTBOUND,
    invoke, operationName))` so `SNACCDeprecated::DeprecatedASN1Method` can read
    `OperationName()` on the context.
-2. **Lookup map:** `SnaccRoseOperationLookup::LookUpName()` is a parachute when
-   the stub name is absent on outbound paths. Registration in the lookup map is
-   optional but required for inbound context naming when only `operationID` is known.
+2. **Lookup table (UCAAS-1485):** `SnaccRoseOperationLookup` holds operation id/name/interface
+   mappings for one listener context. Fill at startup via
+   `ENetUC_*ROSE::RegisterOperations(lookup)` (static; no stub instances required),
+   then call `Seal()`. Mounting a generated `*ROSE` component does not register operations. `SnaccROSEBase` borrows a const lookup reference for the stub
+   lifetime; lookup after seal needs no locking. Outbound stub literals remain authoritative;
+   lookup by operationID is the inbound parachute when only the id is known.
 3. **Inbound invokes:** `operationID` is authoritative for dispatch. When the client
    sends `operationID: 0` with `operationName`, `PrepareInboundInvokeOperationId`
    resolves the ID via `LookUpID` before stub dispatch and before the invoke context

--- a/cpp-lib/tests/telemetry_tests.cpp
+++ b/cpp-lib/tests/telemetry_tests.cpp
@@ -339,7 +339,7 @@ protected:
 		});
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(25));
-		m_client.StopProcessing(true);
+		m_client.PauseRoseProcessing();
 
 		EXPECT_EQ(ROSE_TE_SHUTDOWN, pendingInvoke.get());
 
@@ -465,7 +465,7 @@ protected:
 		ASSERT_EQ(ROSE_NOERROR, sendResult);
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(25));
-		m_client.StopProcessing(true);
+		m_client.PauseRoseProcessing();
 
 		ASSERT_TRUE(latch.WaitFor(std::chrono::milliseconds(500)));
 

--- a/cpp-lib/tests/test_support/sample_runtime_harness.h
+++ b/cpp-lib/tests/test_support/sample_runtime_harness.h
@@ -506,7 +506,7 @@ public:
 		  m_strSessionId(sessionId),
 		  m_wstrSessionId(ToWide(sessionId))
 	{
-		StopProcessing(false);
+		ResumeRoseProcessing();
 	}
 
 	/*! Test helper: registers operations on this endpoint's lookup table (before Seal). */

--- a/cpp-lib/tests/test_support/sample_runtime_harness.h
+++ b/cpp-lib/tests/test_support/sample_runtime_harness.h
@@ -501,12 +501,36 @@ class RuntimeEndpoint : public SnaccROSEBase
 {
 public:
 	// Creates one connection host with a stable logical session id for tests.
-	RuntimeEndpoint(const wchar_t* className, const std::string& sessionId)
-		: SnaccROSEBase(className),
+	RuntimeEndpoint(const wchar_t* className, const std::string& sessionId, SnaccRoseOperationLookup& operationLookup)
+		: SnaccROSEBase(className, operationLookup),
 		  m_strSessionId(sessionId),
 		  m_wstrSessionId(ToWide(sessionId))
 	{
 		StopProcessing(false);
+	}
+
+	/*! Test helper: registers operations on this endpoint's lookup table (before Seal). */
+	void RegisterOperation(
+		unsigned int uiOpID,
+		const char* szOpName,
+		unsigned int uiInterfaceID,
+		const char* szModuleName,
+		bool bIsEvent = false,
+		unsigned long long ullAddedUnix = 0,
+		unsigned long long ullDeprecatedUnix = 0)
+	{
+		OperationLookupForRegistration().RegisterOperation(uiOpID, szOpName, uiInterfaceID, szModuleName, bIsEvent, ullAddedUnix, ullDeprecatedUnix);
+	}
+
+	/*! Test helper: clears this endpoint's lookup table (before Seal). */
+	void ClearRegisteredOperations()
+	{
+		OperationLookupForRegistration().ClearRegisteredOperations();
+	}
+
+	SnaccRoseOperationLookup& MutableOperationLookup()
+	{
+		return OperationLookupForRegistration();
 	}
 
 	// Attaches a loopback transport that forwards outbound data to the peer host.
@@ -675,7 +699,10 @@ private:
 class ObservedRuntimeEndpoint : public RuntimeEndpoint
 {
 public:
-	using RuntimeEndpoint::RuntimeEndpoint;
+	ObservedRuntimeEndpoint(const wchar_t* className, const std::string& sessionId, SnaccRoseOperationLookup& operationLookup)
+		: RuntimeEndpoint(className, sessionId, operationLookup)
+	{
+	}
 
 	// Configures the active log levels independently for inbound and outbound traffic.
 	void SetLogLevels(const EAsnLogLevel inbound, const EAsnLogLevel outbound)
@@ -800,6 +827,7 @@ public:
 		: m_endpoint(endpoint),
 		  m_component(&endpoint)
 	{
+		ENetUC_Settings_ManagerROSE::RegisterOperations(m_endpoint.MutableOperationLookup());
 		m_endpoint.RegisterModule(*this);
 	}
 
@@ -894,6 +922,7 @@ public:
 		: m_endpoint(endpoint),
 		  m_component(&endpoint)
 	{
+		ENetUC_Settings_ManagerROSE::RegisterOperations(m_endpoint.MutableOperationLookup());
 		m_endpoint.RegisterModule(*this);
 	}
 
@@ -1029,6 +1058,7 @@ public:
 		: m_endpoint(endpoint),
 		  m_component(&endpoint)
 	{
+		ENetUC_Event_ManagerROSE::RegisterOperations(m_endpoint.MutableOperationLookup());
 		m_endpoint.RegisterModule(*this);
 	}
 
@@ -1102,6 +1132,7 @@ public:
 		: m_endpoint(endpoint),
 		  m_component(&endpoint)
 	{
+		ENetUC_Event_ManagerROSE::RegisterOperations(m_endpoint.MutableOperationLookup());
 		m_endpoint.RegisterModule(*this);
 	}
 
@@ -1394,8 +1425,10 @@ protected:
 
 	TelemetryRecorder m_telemetryRecorder;   // collects callback records emitted by SnaccROSEBase
 	ScopedTelemetryCapture m_telemetryScope; // keeps telemetry callback capture installed for the fixture lifetime
-	ObservedRuntimeEndpoint m_server{L"LoopbackServer", "server-session"}; // server-side session host used by all tests
-	ObservedRuntimeEndpoint m_client{L"LoopbackClient", "client-session"}; // client-side session host used by all tests
+	SnaccRoseOperationLookup m_serverLookup; // listener lookup table for server session host
+	SnaccRoseOperationLookup m_clientLookup; // listener lookup table for client session host
+	ObservedRuntimeEndpoint m_server{L"LoopbackServer", "server-session", m_serverLookup}; // server-side session host used by all tests
+	ObservedRuntimeEndpoint m_client{L"LoopbackClient", "client-session", m_clientLookup}; // client-side session host used by all tests
 	SettingsServiceModule m_serverSettingsModule; // server module handling settings invokes
 	SettingsClientModule m_clientSettingsModule;  // client module issuing settings invokes and receiving settings events
 	EventServiceModule m_serverEventModule;       // server module handling event-manager invokes

--- a/version.h
+++ b/version.h
@@ -1,8 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERSION "7.0.13"
-#define VERSION_RC 7, 0, 13
+#define VERSION "7.0.14"
+#define VERSION_RC 7, 0, 14
 #define RELDATE "17.08.2026"
 
 #endif // VERSION_H

--- a/version.h
+++ b/version.h
@@ -3,6 +3,6 @@
 
 #define VERSION "7.0.14"
 #define VERSION_RC 7, 0, 14
-#define RELDATE "17.08.2026"
+#define RELDATE "18.08.2026"
 
 #endif // VERSION_H


### PR DESCRIPTION
## Summary

UCAAS-1485 phase 1: per-listener operation/module registry for capability handshake groundwork, plus a cleaner transport-session ROSE processing API.

### Per-listener `SnaccRoseOperationLookup`

- New `SnaccRoseOperationLookup` class: register modules/ops with `@added` / `@deprecated` metadata, `Seal()` after startup, read-only lookup thereafter.
- `SnaccROSEBase` takes a lookup reference at construction; lookup methods delegate to the listener-owned table.
- C++ codegen emits only `static void RegisterOperations(SnaccRoseOperationLookup& lookup)` — no ctor auto-registration.
- `SnaccRoseRegisterHost` helper for filling lookup tables at listener startup.
- Tests/harness updated for explicit static registration + `Seal()`.

### Transport-session processing gate

- **Removed** `StopProcessing(bool)`.
- **Added** `PauseRoseProcessing()` / `ResumeRoseProcessing()` on `SnaccROSEBase`.
  - `PauseRoseProcessing()` — block new inbound/outbound ROSE work and complete pending ops with `ROSE_TE_SHUTDOWN` (call on transport disconnect).
  - `ResumeRoseProcessing()` — reopen processing on a reused stub (call when starting a new transport session, e.g. reconnect).
- Runtime tests and `runtime_correctness_notes.md` updated.

### Version

- **7.0.14** (bumped on this branch)
- `RELDATE` **18.08.2026**

## Breaking changes

- `SnaccROSEBase` constructor requires `SnaccRoseOperationLookup&`.
- Generated `RegisterOperations()` is static and takes the lookup table.
- `StopProcessing()` removed — use `PauseRoseProcessing()` / `ResumeRoseProcessing()`.
- Product code: pair `PauseRoseProcessing()` on disconnect with `ResumeRoseProcessing()` on connect (`ENetCtiClientBase` pattern).

## Test plan

- [x] CMake Release build (Windows + Ubuntu CI)
- [x] `ctest` — module registry, public API, lifecycle, async invoke, telemetry tests
- [x] Regenerate ProCall `ENetConnection_*` client stubs with esnacc 7.0.14
- [x] Verify UCServer / ProCall client compile against new `SnaccROSEBase` ctor and Pause/Resume API
- [x] Manual reconnect: stub resumes ROSE processing after transport reconnect